### PR TITLE
Update GTM id

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,7 +127,7 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         gtag: {
-          trackingID: 'G-KW4FDPBLLJ',
+          trackingID: 'GTM-WBZS43V',
           anonymizeIP: true,
         },
       }),


### PR DESCRIPTION
replace GA4 id with GTM id

https://tagmanager.google.com/?hl=zh-CN_cn#/container/accounts/6006808381/containers/66687760/workspaces/3