### PR TITLE
update URL of TiDB Cloud free trial

### DIFF
--- a/blog/explore-deep-in-4.6-billion-github-events/index.md
+++ b/blog/explore-deep-in-4.6-billion-github-events/index.md
@@ -329,7 +329,7 @@ order by 2 desc;
 
 ## Run your own analytics with TiDB Cloud
 
-All the analytics on **[OSSInsight.io](https://ossinsight.io/)** are powered by [TiDB Cloud](https://en.pingcap.com/tidb-cloud/), a fully-managed database as a service. If you want to run your own analytics and get your own insights, [sign up for a TiDB Cloud account](https://tidbcloud.com/signup?utm_source=ossinsight&utm_medium=referral) and try it for yourself with this [10-minute tutorial](https://ossinsight.io/blog/try-it-yourself/).
+All the analytics on **[OSSInsight.io](https://ossinsight.io/)** are powered by [TiDB Cloud](https://en.pingcap.com/tidb-cloud/), a fully-managed database as a service. If you want to run your own analytics and get your own insights, [sign up for a TiDB Cloud account](https://tidbcloud.com/free-trial?utm_source=ossinsight&utm_medium=referral) and try it for yourself with this [10-minute tutorial](https://ossinsight.io/blog/try-it-yourself/).
 
 ## Contact us 
 

--- a/blog/how-it-works/index.md
+++ b/blog/how-it-works/index.md
@@ -164,7 +164,7 @@ gharchive_dev> show tables;
 :::info
 ### 🌟 Details in how OSS Insight works
 
-Go to read [Use TiDB Cloud to Analyze GitHub Events in 10 Minutes](/blog/try-it-yourself) and use the [Developer Tier](https://tidbcloud.com/signup?utm_source=ossinsight&utm_medium=referral) **free** for 1 year.
+Go to read [Use TiDB Cloud to Analyze GitHub Events in 10 Minutes](/blog/try-it-yourself) and use the [Developer Tier](https://tidbcloud.com/free-trial?utm_source=ossinsight&utm_medium=referral) **free** for 1 year.
 
 You can find the reason [Why We Choose TiDB to Support OSS Insight](/blog/why-we-choose-tidb-to-support-oss-insight) as well!
 :::

--- a/blog/saas-insight-for-building-a-real-time-crm-application.md
+++ b/blog/saas-insight-for-building-a-real-time-crm-application.md
@@ -40,7 +40,7 @@ For more cases, please see [here](https://en.pingcap.com/customers/?utm_source=o
 :::info
 ### 🌟 Details in how OSS Insight works
 
-Go to read [Use TiDB Cloud to Analyze GitHub Events in 10 Minutes](/blog/try-it-yourself) and use the [Developer Tier](https://tidbcloud.com/signup?utm_source=ossinsight&utm_medium=referral) **free** for 1 year.
+Go to read [Use TiDB Cloud to Analyze GitHub Events in 10 Minutes](/blog/try-it-yourself) and use the [Developer Tier](https://tidbcloud.com/free-trial?utm_source=ossinsight&utm_medium=referral) **free** for 1 year.
 
 You can find how we deal with massive github data in [Data Preparation for Analytics](/blog/how-it-works) as well!
 :::

--- a/blog/try-it-yourself/index.md
+++ b/blog/try-it-yourself/index.md
@@ -13,7 +13,7 @@ In this tutorial, we will provide you with a piece of sample data of all GitHub 
 
 ## Sign up for a TiDB Cloud account (Free)
 
-1. Click [here](https://tidbcloud.com/signup?utm_source=ossinsight&utm_medium=referral) to sign up for a TiDB Cloud account free of charge. 
+1. Click [here](https://tidbcloud.com/free-trial?utm_source=ossinsight&utm_medium=referral) to sign up for a TiDB Cloud account free of charge. 
 2. [Log in](https://tidbcloud.com/?utm_source=ossinsight&utm_medium=referral) to your account.
 
 <!--truncate-->

--- a/blog/why-we-choose-tidb-to-support-oss-insight/index.md
+++ b/blog/why-we-choose-tidb-to-support-oss-insight/index.md
@@ -45,7 +45,7 @@ Unleashing the value of real-time data has become more and more important, and h
 :::info
 ### 🌟 Details in how OSS Insight works
 
-Go to read [Use TiDB Cloud to Analyze GitHub Events in 10 Minutes](/blog/try-it-yourself) and use the [Developer Tier](https://tidbcloud.com/signup?utm_source=ossinsight&utm_medium=referral) **free** for 1 year.
+Go to read [Use TiDB Cloud to Analyze GitHub Events in 10 Minutes](/blog/try-it-yourself) and use the [Developer Tier](https://tidbcloud.com/free-trial?utm_source=ossinsight&utm_medium=referral) **free** for 1 year.
 
 You can find how we deal with massive github data in [Data Preparation for Analytics](/blog/how-it-works) as well!
 :::


### PR DESCRIPTION
Since we have a new website for quick signup, it is better than we replace https://tidbcloud.com/signup with https://tidbcloud.com/free-trial in the URL.