### PR TITLE
Add finance collection

### DIFF
--- a/backend/meta/collections/10030.finance.yml
+++ b/backend/meta/collections/10030.finance.yml
@@ -1,0 +1,17 @@
+id: 10030
+name: Finance
+items:
+  - OpenBB-finance/OpenBBTerminal
+  - vnpy/vnpy
+  - waditu/tushare
+  - microsoft/qlib
+  - ranaroussi/yfinance
+  - mrjbq7/ta-lib
+  - QuantConnect/Lean
+  - akfamily/akshare
+  - StockSharp/StockSharp
+  - ricequant/rqalpha
+  - robertmartin8/PyPortfolioOpt
+  - twopirllc/pandas-ta
+  - quantopian/alphalens
+  - ranaroussi/quantstats


### PR DESCRIPTION
Hey 👋🏽 

I am the creator behind [OpenBB-finance/OpenBBTerminal](OpenBB-finance/OpenBBTerminal) and thought it would be nice for you to have a finance topic for your collections.

I selected the projects based on the number of stars when searching for `finance` tag, see https://github.com/search?o=desc&p=1&q=finance&s=stars&type=Repositories

I didn't add some of the projects because I didn't really consider them "finance", for instance:
* a repository that just contains a list of nice finance resources.
* a plotting library that can be used to plot historical data.

Feel free to add more packages if you think that some are missing, or to remove some if you don't think they should be there.

