### PR TITLE
Add PyTorch lightning to 10010.artificial-intelligence.yml

### DIFF
--- a/backend/meta/collections/10010.artificial-intelligence.yml
+++ b/backend/meta/collections/10010.artificial-intelligence.yml
@@ -5,6 +5,7 @@ items:
   - huggingface/transformers
   - opencv/opencv
   - pytorch/pytorch
+  - Lightning-AI/lightning
   - keras-team/keras
   - scikit-learn/scikit-learn
   - ageitgey/face_recognition


### PR DESCRIPTION
PyTorch Lightning is one of the most popular repos in ML that is missing from the list for AI