### PR TITLE
fix: fix contribute to repos be zero problem

### DIFF
--- a/api/queries/personal-overview/template.sql
+++ b/api/queries/personal-overview/template.sql
@@ -1,5 +1,5 @@
 WITH logins AS (
-    SELECT DISTINCT actor_id, actor_login
+    SELECT DISTINCT actor_login
     FROM github_events ge
     WHERE actor_id = 5086433
 ), latest_login AS (
@@ -11,7 +11,7 @@ WITH logins AS (
 ), repos AS (
     SELECT DISTINCT repo_id, repo_name
     FROM github_events ge
-    WHERE ge.actor_id = 5086433 AND repo_name LIKE CONCAT(actor_login, '%')
+    WHERE ge.actor_id = 5086433 AND repo_name LIKE CONCAT(actor_login, '%') AND repo_id IS NOT NULL
 ), star_repos AS (
     SELECT COUNT(DISTINCT repo_id) AS cnt
     FROM github_events ge


### PR DESCRIPTION
> NOT IN returns 0 records when compared against an unknown value
> Since NULL is an unknown, a NOT IN query containing a NULL or NULLs in the list of possible values will always return 0 records since there is no way to be sure that the NULL value is not the value being tested.

https://stackoverflow.com/a/129151