### PR TITLE
fix(analyze-user): the y-axis was cached even if the meta data has been updated

### DIFF
--- a/src/dynamic-pages/analyze-user/sections/1-Behaviour.tsx
+++ b/src/dynamic-pages/analyze-user/sections/1-Behaviour.tsx
@@ -59,7 +59,7 @@ const AllContributions = ({ userId, show }: ModuleProps) => {
   return (
     <ChartWrapper title="Type of total contributions">
       <EChartsx init={{ height: 800, renderer: 'canvas' }} theme="dark">
-        <Once>
+        <Once dependencies={[repos]}>
           <Common hideZoom />
           <Axis.Value.X />
           <Axis.Category.Y data={repos} inverse />


### PR DESCRIPTION
We will see the incorrect y-axis when history back, which is caused by the useMemo.

https://user-images.githubusercontent.com/11549583/177561331-ab195808-c4d1-40e4-8e17-0876f80b2124.mov


