### PR TITLE
fix: get user id by login should get the latest one

### DIFF
--- a/api/queries/get-user-by-login/template.sql
+++ b/api/queries/get-user-by-login/template.sql
@@ -1,1 +1,8 @@
-select actor_id AS id, 'Mini256' AS login from github_events where actor_login = 'Mini256' AND actor_id IS NOT NULL limit 1;
+SELECT
+    actor_id AS id, 'Mini256' AS login
+FROM github_events
+WHERE
+    actor_login = 'Mini256'
+    AND actor_id IS NOT NULL
+ORDER BY created_at DESC
+LIMIT 1;


### PR DESCRIPTION
Some GitHub users may register multiple accounts one after another but use the same login.

```
gharchive_dev> SELECT
            ->     DISTINCT actor_id AS id, 'PsiACE' AS login
            -> FROM github_events
            -> WHERE
            ->     actor_login = 'PsiACE'
            ->     AND actor_id IS NOT NULL
            -> ;
+----------+--------+
| id       | login  |
+----------+--------+
| 36896360 | PsiACE |
| 25458566 | PsiACE |
| 25342314 | PsiACE |
+----------+--------+
3 rows in set
Time: 0.115s
```