### PR TITLE
feat(sql): add repo last 28 days queries

### DIFF
--- a/api/queries/analyze-recent-commits/params.json
+++ b/api/queries/analyze-recent-commits/params.json
@@ -1,0 +1,10 @@
+{
+  "cacheHours": 1,
+  "params": [
+    {
+      "name": "repoId",
+      "replaces": "41986369",
+      "pattern": "^[1-9]\\d*$"
+    }
+  ]
+}

--- a/api/queries/analyze-recent-commits/template.sql
+++ b/api/queries/analyze-recent-commits/template.sql
@@ -1,0 +1,60 @@
+WITH RECURSIVE seq(idx) AS (
+      SELECT 1 AS idx
+      UNION ALL
+      SELECT idx + 1 AS idx
+      FROM seq
+      WHERE idx < 28
+), group_by_day AS (
+    SELECT
+        day_offset % 28 + 1 AS idx,
+        day_offset DIV 28 AS period,
+        day,
+        commits
+    FROM (
+        SELECT
+            (DATEDIFF(CURRENT_DATE(), day)) AS day_offset,
+            day,
+            commits
+        FROM (
+            SELECT
+                DATE_FORMAT(created_at, '%Y-%m-%d') AS day,
+                SUM(push_distinct_size) AS commits
+            FROM
+                github_events ge
+            WHERE
+                type = 'PushEvent'
+                AND repo_id = 20580498
+                AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+                AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
+            GROUP BY day
+            ORDER BY day
+        ) sub
+    ) sub2
+), last_28_days AS (
+    SELECT idx, day, commits
+    FROM group_by_day
+    WHERE period = 0
+), last_2nd_28_days AS (
+    SELECT idx, day, commits
+    FROM group_by_day
+    WHERE period = 1
+), last_28_days_total AS (
+    SELECT SUM(commits) AS total FROM last_28_days
+), last_2nd_28_days_total AS (
+    SELECT SUM(commits) AS total FROM last_2nd_28_days
+)
+SELECT
+    s.idx AS idx,
+    cp.day AS current_period_day,
+    IFNULL(cp.commits, 0) AS current_period_day_commits,
+    IFNULL(cpt.total, 0) AS current_period_commits,
+    lp.day AS last_period_day,
+    IFNULL(lp.commits, 0) AS last_period_day_commits,
+    IFNULL(lpt.total, 0) AS last_period_commits
+FROM seq s
+LEFT JOIN last_28_days cp ON s.idx = cp.idx
+LEFT JOIN last_2nd_28_days lp ON s.idx = lp.idx
+JOIN last_28_days_total cpt ON 1 = 1
+JOIN last_2nd_28_days_total lpt ON 1 = 1
+ORDER BY idx
+;

--- a/api/queries/analyze-recent-issues/params.json
+++ b/api/queries/analyze-recent-issues/params.json
@@ -1,0 +1,10 @@
+{
+  "cacheHours": 1,
+  "params": [
+    {
+      "name": "repoId",
+      "replaces": "41986369",
+      "pattern": "^[1-9]\\d*$"
+    }
+  ]
+}

--- a/api/queries/analyze-recent-issues/template.sql
+++ b/api/queries/analyze-recent-issues/template.sql
@@ -1,0 +1,109 @@
+WITH RECURSIVE seq(idx) AS (
+      SELECT 1 AS idx
+      UNION ALL
+      SELECT idx + 1 AS idx
+      FROM seq
+      WHERE idx < 28
+), opened_issues_group_by_day AS (
+    SELECT
+        day_offset % 28 + 1 AS idx,
+        day_offset DIV 28 AS period,
+        day,
+        issues
+    FROM (
+        SELECT
+            (DATEDIFF(CURRENT_DATE(), day)) AS day_offset,
+            day,
+            issues
+        FROM (
+            SELECT
+                DATE_FORMAT(created_at, '%Y-%m-%d') AS day,
+                COUNT(*) AS issues
+            FROM
+                github_events ge
+            WHERE
+                type = 'PullRequestEvent'
+                AND action = 'opened'
+                AND repo_id = 41986369
+                AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+                AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
+            GROUP BY day
+            ORDER BY day
+        ) sub
+    ) sub2
+), closed_issues_group_by_day AS (
+    SELECT
+        day_offset % 28 + 1 AS idx,
+        day_offset DIV 28 AS period,
+        day,
+        issues
+    FROM (
+        SELECT
+            (DATEDIFF(CURRENT_DATE(), day)) AS day_offset,
+            day,
+            issues
+        FROM (
+            SELECT
+                DATE_FORMAT(created_at, '%Y-%m-%d') AS day,
+                COUNT(*) AS issues
+            FROM
+                github_events ge
+            WHERE
+                type = 'PullRequestEvent'
+                AND action = 'closed'
+                AND pr_merged = true
+                AND repo_id = 41986369
+                AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+                AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
+            GROUP BY day
+            ORDER BY day
+        ) sub
+    ) sub2
+), opened_issues_last_28_days AS (
+    SELECT idx, day, issues
+    FROM opened_issues_group_by_day
+    WHERE period = 0
+), opened_issues_last_2nd_28_days AS (
+    SELECT idx, day, issues
+    FROM opened_issues_group_by_day
+    WHERE period = 1
+), closed_issues_last_28_days AS (
+    SELECT idx, day, issues
+    FROM closed_issues_group_by_day
+    WHERE period = 0
+), closed_issues_last_2nd_28_days AS (
+    SELECT idx, day, issues
+    FROM closed_issues_group_by_day
+    WHERE period = 1
+), opened_issues_last_28_days_total AS (
+    SELECT SUM(issues) AS total FROM opened_issues_last_28_days
+), opened_issues_last_2nd_28_days_total AS (
+    SELECT SUM(issues) AS total FROM opened_issues_last_2nd_28_days
+), closed_issues_last_28_days_total AS (
+    SELECT SUM(issues) AS total FROM closed_issues_last_28_days
+), closed_issues_last_2nd_28_days_total AS (
+    SELECT SUM(issues) AS total FROM closed_issues_last_2nd_28_days
+)
+SELECT
+    s.idx AS idx,
+    COALESCE(oicp.day, cicp.day) AS current_period_day,
+    IFNULL(oicp.issues, 0) AS current_period_opened_day_issues,
+    IFNULL(oicpt.total, 0) AS current_period_opened_issues,
+    IFNULL(oilp.issues, 0) AS last_period_opened_day_issues,
+    IFNULL(oilpt.total, 0) AS last_period_opened_issues,
+    COALESCE(oilp.day, cilp.day) AS last_period_day,
+    IFNULL(cicp.issues, 0) AS current_period_closed_day_issues,
+    IFNULL(cicpt.total, 0) AS current_period_closed_issues,
+    IFNULL(cilp.issues, 0) AS last_period_closed_day_issues,
+    IFNULL(cilpt.total, 0) AS last_period_closed_issues
+FROM seq s
+LEFT JOIN opened_issues_last_28_days oicp ON s.idx = oicp.idx
+LEFT JOIN opened_issues_last_2nd_28_days oilp ON s.idx = oilp.idx
+LEFT JOIN closed_issues_last_28_days cicp ON s.idx = cicp.idx
+LEFT JOIN closed_issues_last_2nd_28_days cilp ON s.idx = cilp.idx
+JOIN opened_issues_last_28_days_total oicpt ON 1 = 1
+JOIN opened_issues_last_2nd_28_days_total oilpt ON 1 = 1
+JOIN closed_issues_last_28_days_total cicpt ON 1 = 1
+JOIN closed_issues_last_2nd_28_days_total cilpt ON 1 = 1
+ORDER BY idx
+;

--- a/api/queries/analyze-recent-pull-requests/params.json
+++ b/api/queries/analyze-recent-pull-requests/params.json
@@ -1,0 +1,10 @@
+{
+  "cacheHours": 1,
+  "params": [
+    {
+      "name": "repoId",
+      "replaces": "41986369",
+      "pattern": "^[1-9]\\d*$"
+    }
+  ]
+}

--- a/api/queries/analyze-recent-pull-requests/template.sql
+++ b/api/queries/analyze-recent-pull-requests/template.sql
@@ -1,0 +1,108 @@
+WITH RECURSIVE seq(idx) AS (
+      SELECT 1 AS idx
+      UNION ALL
+      SELECT idx + 1 AS idx
+      FROM seq
+      WHERE idx < 28
+), opened_prs_group_by_day AS (
+    SELECT
+        day_offset % 28 + 1 AS idx,
+        day_offset DIV 28 AS period,
+        day,
+        prs
+    FROM (
+        SELECT
+            (DATEDIFF(CURRENT_DATE(), day)) AS day_offset,
+            day,
+            prs
+        FROM (
+            SELECT
+                DATE_FORMAT(created_at, '%Y-%m-%d') AS day,
+                COUNT(*) AS prs
+            FROM
+                github_events ge
+            WHERE
+                type = 'PullRequestEvent'
+                AND action = 'opened'
+                AND repo_id = 41986369
+                AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+                AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
+            GROUP BY day
+            ORDER BY day
+        ) sub
+    ) sub2
+), merged_prs_group_by_day AS (
+    SELECT
+        day_offset % 28 + 1 AS idx,
+        day_offset DIV 28 AS period,
+        day,
+        prs
+    FROM (
+        SELECT
+            (DATEDIFF(CURRENT_DATE(), day)) AS day_offset,
+            day,
+            prs
+        FROM (
+            SELECT
+                DATE_FORMAT(created_at, '%Y-%m-%d') AS day,
+                COUNT(*) AS prs
+            FROM
+                github_events ge
+            WHERE
+                type = 'PullRequestEvent'
+                AND action = 'closed'
+                AND pr_merged = true
+                AND repo_id = 41986369
+                AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+                AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
+            GROUP BY day
+            ORDER BY day
+        ) sub
+    ) sub2
+), opened_prs_last_28_days AS (
+    SELECT idx, day, prs
+    FROM opened_prs_group_by_day
+    WHERE period = 0
+), opened_prs_last_2nd_28_days AS (
+    SELECT idx, day, prs
+    FROM opened_prs_group_by_day
+    WHERE period = 1
+), merged_prs_last_28_days AS (
+    SELECT idx, day, prs
+    FROM merged_prs_group_by_day
+    WHERE period = 0
+), merged_prs_last_2nd_28_days AS (
+    SELECT idx, day, prs
+    FROM merged_prs_group_by_day
+    WHERE period = 1
+), opened_prs_last_28_days_total AS (
+    SELECT SUM(prs) AS total FROM opened_prs_last_28_days
+), opened_prs_last_2nd_28_days_total AS (
+    SELECT SUM(prs) AS total FROM opened_prs_last_2nd_28_days
+), merged_prs_last_28_days_total AS (
+    SELECT SUM(prs) AS total FROM merged_prs_last_28_days
+), merged_prs_last_2nd_28_days_total AS (
+    SELECT SUM(prs) AS total FROM merged_prs_last_2nd_28_days
+)
+SELECT
+    s.idx AS idx,
+    COALESCE(opcp.day, mpcp.day) AS current_period_day,
+    IFNULL(opcp.prs, 0) AS current_period_opened_day_prs,
+    IFNULL(opcpt.total, 0) AS current_period_opened_prs,
+    IFNULL(oplp.prs, 0) AS last_period_opened_day_prs,
+    IFNULL(oplpt.total, 0) AS last_period_opened_prs,
+    COALESCE(oplp.day, mplp.day) AS last_period_day,
+    IFNULL(mpcp.prs, 0) AS current_period_merged_day_prs,
+    IFNULL(mpcpt.total, 0) AS current_period_merged_prs,
+    IFNULL(mplp.prs, 0) AS last_period_merged_day_prs,
+    IFNULL(mplpt.total, 0) AS last_period_merged_prs
+FROM seq s
+LEFT JOIN opened_prs_last_28_days opcp ON s.idx = opcp.idx
+LEFT JOIN opened_prs_last_2nd_28_days oplp ON s.idx = oplp.idx
+LEFT JOIN merged_prs_last_28_days mpcp ON s.idx = mpcp.idx
+LEFT JOIN merged_prs_last_2nd_28_days mplp ON s.idx = mplp.idx
+JOIN opened_prs_last_28_days_total opcpt ON 1 = 1
+JOIN opened_prs_last_2nd_28_days_total oplpt ON 1 = 1
+JOIN merged_prs_last_28_days_total mpcpt ON 1 = 1
+JOIN merged_prs_last_2nd_28_days_total mplpt ON 1 = 1
+ORDER BY idx

--- a/api/queries/analyze-recent-stars/params.json
+++ b/api/queries/analyze-recent-stars/params.json
@@ -1,0 +1,10 @@
+{
+  "cacheHours": 1,
+  "params": [
+    {
+      "name": "repoId",
+      "replaces": "41986369",
+      "pattern": "^[1-9]\\d*$"
+    }
+  ]
+}

--- a/api/queries/analyze-recent-stars/template.sql
+++ b/api/queries/analyze-recent-stars/template.sql
@@ -1,0 +1,60 @@
+WITH RECURSIVE seq(idx) AS (
+      SELECT 1 AS idx
+      UNION ALL
+      SELECT idx + 1 AS idx
+      FROM seq
+      WHERE idx < 28
+), group_by_day AS (
+    SELECT
+        day_offset % 28 + 1 AS idx,
+        day_offset DIV 28 AS period,
+        day,
+        stars
+    FROM (
+        SELECT
+            (DATEDIFF(CURRENT_DATE(), day)) AS day_offset,
+            day,
+            stars
+        FROM (
+            SELECT
+                DATE_FORMAT(created_at, '%Y-%m-%d') AS day,
+                COUNT(*) AS stars
+            FROM
+                github_events ge
+            WHERE
+                type = 'WatchEvent'
+                AND repo_id = 41986369
+                AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+                AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
+            GROUP BY day
+            ORDER BY day
+        ) sub
+    ) sub2
+), last_28_days AS (
+    SELECT idx, day, stars
+    FROM group_by_day
+    WHERE period = 0
+), last_2nd_28_days AS (
+    SELECT idx, day, stars
+    FROM group_by_day
+    WHERE period = 1
+), last_28_days_total AS (
+    SELECT SUM(stars) AS total FROM last_28_days
+), last_2nd_28_days_total AS (
+    SELECT SUM(stars) AS total FROM last_2nd_28_days
+)
+SELECT
+    s.idx AS idx,
+    cp.day AS current_period_day,
+    IFNULL(cp.stars, 0) AS current_period_day_stars,
+    IFNULL(cpt.total, 0) AS current_period_stars,
+    lp.day AS last_period_day,
+    IFNULL(lp.stars, 0) AS last_period_day_stars,
+    IFNULL(lpt.total, 0) AS last_period_stars
+FROM seq s
+LEFT JOIN last_28_days cp ON s.idx = cp.idx
+LEFT JOIN last_2nd_28_days lp ON s.idx = lp.idx
+JOIN last_28_days_total cpt ON 1 = 1
+JOIN last_2nd_28_days_total lpt ON 1 = 1
+ORDER BY idx
+;

--- a/api/queries/analyze-recent-top-contributors/params.json
+++ b/api/queries/analyze-recent-top-contributors/params.json
@@ -1,0 +1,10 @@
+{
+  "cacheHours": 1,
+  "params": [
+    {
+      "name": "repoId",
+      "replaces": "41986369",
+      "pattern": "^[1-9]\\d*$"
+    }
+  ]
+}

--- a/api/queries/analyze-recent-top-contributors/template.sql
+++ b/api/queries/analyze-recent-top-contributors/template.sql
@@ -1,0 +1,62 @@
+WITH prs AS (
+    SELECT
+        actor_login, COUNT(*) AS events
+    FROM
+        github_events ge
+    WHERE
+        repo_id = 41986369
+        AND type = 'PullRequestEvent'
+        AND action = 'opened'
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+    GROUP BY actor_login
+), issues AS (
+    SELECT
+        actor_login, COUNT(*) AS events
+    FROM
+        github_events ge
+    WHERE
+        repo_id = 41986369
+        AND type = 'IssuesEvent'
+        AND action = 'opened'
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+    GROUP BY actor_login
+), reviews AS (
+    SELECT
+        actor_login, COUNT(*) AS events
+    FROM
+        github_events ge
+    WHERE
+        repo_id = 41986369
+        AND type = 'PullRequestReviewEvent'
+        AND action = 'created'
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+    GROUP BY actor_login
+), pushes AS (
+    SELECT
+        actor_login, COUNT(*) AS events
+    FROM
+        github_events ge
+    WHERE
+        repo_id = 41986369
+        AND type = 'PushEvent'
+        AND action IS NULL
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+    GROUP BY actor_login
+)
+SELECT actor_login, actor_login, events
+FROM (
+    SELECT * FROM prs
+    UNION
+    SELECT * FROM issues
+    UNION
+    SELECT * FROM reviews
+    UNION
+    SELECT * FROM pushes
+)
+GROUP BY actor_login
+ORDER BY events DESC
+LIMIT 5

--- a/api/queries/analyze-stars-map/params.json
+++ b/api/queries/analyze-stars-map/params.json
@@ -1,0 +1,23 @@
+{
+  "cacheHours": 1,
+  "params": [
+    {
+      "name": "repoId",
+      "replaces": "41986369",
+      "pattern": "^[1-9]\\d*$"
+    },
+    {
+      "name": "period",
+      "replaces": "AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))",
+      "enums": [
+        "last_28_days",
+        "all_times"
+      ],
+      "default": "all_times",
+      "template": {
+        "last_28_days": "AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))",
+        "all_times": ""
+      }
+    }
+  ]
+}

--- a/api/queries/analyze-stars-map/template.sql
+++ b/api/queries/analyze-stars-map/template.sql
@@ -1,0 +1,21 @@
+WITH group_by_area AS (
+    SELECT
+        UPPER(u.country_code) AS country_or_area,
+        COUNT(1) as cnt
+    FROM github_events ge
+    LEFT JOIN users_refined u ON ge.actor_login = u.login
+    WHERE
+        repo_id IN (41986369)
+        AND ge.type = 'WatchEvent'
+        AND ge.action = 'started'
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND u.country_code IS NOT NULL
+    GROUP BY country_or_area
+    ORDER BY cnt DESC
+), s AS (
+    SELECT SUM(cnt) AS total FROM group_by_area
+)
+SELECT country_or_area, cnt AS count, cnt / s.total AS percentage
+FROM group_by_area
+JOIN s ON 1 = 1
+;


### PR DESCRIPTION
### Queries

- analyze-recent-commits
- analyze-recent-pull-requests
- analyze-recent-issues
- analyze-recent-stars
- analyze-recent-top-contributors
- analyze-stars-map (we can replace `stars-map` with it, provide [period](https://github.com/pingcap/ossinsight/blob/fbffee1fe3dd5a3b5f15b1b5eeb88da15ac55095/api/queries/analyze-stars-map/params.json) params)