### PR TITLE
sql: use `created_at` instead of `event_month`

### DIFF
--- a/api/queries/analyze-loc-per-month/template.sql
+++ b/api/queries/analyze-loc-per-month/template.sql
@@ -1,15 +1,15 @@
-select
-    date_format(created_at, '%Y-%m-01') as event_month,
-    sum(additions) as additions,
-    sum(deletions) as deletions,
-    sum(additions) - sum(deletions) as net_additions,
-    sum(additions) + sum(deletions) as changes
-from github_events
-where
+SELECT
+    DATE_FORMAT(created_at, '%Y-%m-01') AS event_month,
+    SUM(additions) AS additions,
+    SUM(deletions) AS deletions,
+    SUM(additions) - SUM(deletions) AS net_additions,
+    SUM(additions) + SUM(deletions) AS changes
+FROM github_events
+WHERE
     repo_id = 41986369
-    and type = 'PullRequestEvent'
-    and action = 'closed'
-    and pr_merged = true
-group by 1
-order by 1
+    AND type = 'PullRequestEvent'
+    AND action = 'closed'
+    AND pr_merged = true
+GROUP BY 1
+ORDER BY 1
 ;

--- a/api/queries/analyze-loc-per-month/template.sql
+++ b/api/queries/analyze-loc-per-month/template.sql
@@ -1,5 +1,5 @@
 select
-    event_month,
+    date_format(created_at, '%Y-%m-01') as event_month,
     sum(additions) as additions,
     sum(deletions) as deletions,
     sum(additions) - sum(deletions) as net_additions,
@@ -10,6 +10,6 @@ where
     and type = 'PullRequestEvent'
     and action = 'closed'
     and pr_merged = true
-group by event_month
-order by event_month
+group by 1
+order by 1
 ;

--- a/api/queries/analyze-pull-requests-size-per-month/template.sql
+++ b/api/queries/analyze-pull-requests-size-per-month/template.sql
@@ -1,15 +1,15 @@
 SELECT event_month, xs, s, m, l, xl, all_size
 FROM (
     SELECT
-        event_month,
+        DATE_FORMAT(created_at, '%Y-%m-01') as event_month,
         SUM(CASE WHEN (additions + deletions) < 10 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS xs,
-        SUM(CASE WHEN (additions + deletions) >= 10 AND (additions + deletions) < 30 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS s,
-        SUM(CASE WHEN (additions + deletions) >= 30 AND (additions + deletions) < 100 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS m,
-        SUM(CASE WHEN (additions + deletions) >= 100 AND (additions + deletions) < 500 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS l,
-        SUM(CASE WHEN (additions + deletions) >= 500 AND (additions + deletions) < 1000 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS xl,
-        SUM(CASE WHEN (additions + deletions) >= 1000 THEN 1 ELSE 0 END) OVER (PARTITION BY event_month) AS xxl,
-        COUNT(*) OVER (PARTITION BY event_month) AS all_size,
-        ROW_NUMBER() OVER (PARTITION BY event_month) AS row_num
+        SUM(CASE WHEN (additions + deletions) >= 10 AND (additions + deletions) < 30 THEN 1 ELSE 0 END) OVER(PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01')) AS s,
+        SUM(CASE WHEN (additions + deletions) >= 30 AND (additions + deletions) < 100 THEN 1 ELSE 0 END) OVER(PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01')) AS m,
+        SUM(CASE WHEN (additions + deletions) >= 100 AND (additions + deletions) < 500 THEN 1 ELSE 0 END) OVER(PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01')) AS l,
+        SUM(CASE WHEN (additions + deletions) >= 500 AND (additions + deletions) < 1000 THEN 1 ELSE 0 END) OVER(PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01')) AS xl,
+        SUM(CASE WHEN (additions + deletions) >= 1000 THEN 1 ELSE 0 END) OVER (PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01')) AS xxl,
+        COUNT(*) OVER (PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01')) AS all_size,
+        ROW_NUMBER() OVER (PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01')) AS row_num
     FROM github_events
     WHERE
         type = 'PullRequestEvent'

--- a/api/queries/analyze-pushes-and-commits-per-month/template.sql
+++ b/api/queries/analyze-pushes-and-commits-per-month/template.sql
@@ -1,8 +1,8 @@
 SELECT
-    event_month,
+    DATE_FORMAT(created_at, '%Y-%m-01') as event_month,
     IFNULL(COUNT(*), 0) AS pushes,
     SUM(COALESCE(push_distinct_size, push_size, 0)) AS commits
 FROM github_events
 WHERE repo_id = 41986369 and type = 'PushEvent'
-GROUP BY event_month
-ORDER BY event_month;
+GROUP BY 1
+ORDER BY 1;

--- a/api/queries/commits-time-distribution/params.json
+++ b/api/queries/commits-time-distribution/params.json
@@ -9,16 +9,16 @@
     },
     {
       "name": "period",
-      "replaces": "AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))",
+      "replaces": "AND (created_at BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR) AND CURRENT_DATE())",
       "enums": [
         "last_1_year",
         "last_3_year",
         "all_times"
       ],
-      "default": "last_1_year",
+      "default": "all_times",
       "template": {
-        "last_1_year": "AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))",
-        "last_3_year": "AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 3 YEAR), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))",
+        "last_1_year": "AND (created_at BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR) AND CURRENT_DATE())",
+        "last_3_year": "AND (created_at BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 3 YEAR) AND CURRENT_DATE())",
         "all_times": ""
       }
     }

--- a/api/queries/commits-time-distribution/template.sql
+++ b/api/queries/commits-time-distribution/template.sql
@@ -7,7 +7,7 @@ WHERE
     repo_id = 41986369
     AND type = 'PushEvent'
     AND action IS NULL
-    AND (DATE_FORMAT(created_at, '%Y-%m-01') BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+    AND (created_at BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR) AND CURRENT_DATE())
 GROUP BY dayofweek, hour
 ORDER BY dayofweek, hour
 ;

--- a/api/queries/commits-time-distribution/template.sql
+++ b/api/queries/commits-time-distribution/template.sql
@@ -7,7 +7,7 @@ WHERE
     repo_id = 41986369
     AND type = 'PushEvent'
     AND action IS NULL
-    AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+    AND (DATE_FORMAT(created_at, '%Y-%m-01') BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
 GROUP BY dayofweek, hour
 ORDER BY dayofweek, hour
 ;


### PR DESCRIPTION
Use `created_at` instead of `event_month` now, it will use index automatically when the `add index` task finish.


on (repo_id, type, action, created_at, push_distinct_size, push_size)
on (repo_id, type, action, pr_merged, created_at, additions, deletions)

Close #732 #733