### PR TITLE
Add OWASP dependency-check

### DIFF
--- a/backend/meta/collections/10051.security-tool.yml
+++ b/backend/meta/collections/10051.security-tool.yml
@@ -43,4 +43,4 @@ items:
   - aboul3la/Sublist3r
   - gamelinux/passivedns
   - lanmaster53/recon-ng
-
+  - jeremylong/DependencyCheck


### PR DESCRIPTION
Add OWASP dependency-check - a widely used SCA tool.