### PR TITLE
fix: handle mysql/tidb server connection lost

### DIFF
--- a/api/app/core/cache/CacheBuilder.ts
+++ b/api/app/core/cache/CacheBuilder.ts
@@ -1,5 +1,5 @@
 import { createConnection } from "mysql2";
-import { getConnectionOptions, handleDisconnect } from "../../utils/db";
+import { ConnectionWrapper, getConnectionOptions } from "../../utils/db";
 import Cache from './Cache'
 import CachedTableCacheProvider from "./CachedTableCacheProvider";
 import { CacheOption, CacheProvider } from "./CacheProvider";
@@ -11,11 +11,11 @@ export enum CacheProviderTypes {
 }
 
 class NoneCacheProvider implements CacheProvider {
-    set(key: string, value: any, options?: CacheOption | undefined): void {
-        return;
+    set(key: string, value: any, options?: CacheOption | undefined) {
+        return Promise.resolve();
     }
     get(key: string) {
-        return undefined;
+        return Promise.resolve();
     }
 }
 
@@ -32,12 +32,10 @@ export default class CacheBuilder {
     constructor(enableCache: boolean) {
         this.enableCache = enableCache;
         if (enableCache) {
-            const normalCacheConn = createConnection(getConnectionOptions());
-            handleDisconnect(normalCacheConn);
+            const normalCacheConn = new ConnectionWrapper(getConnectionOptions());
             this.normalCacheProvider = new NormalTableCacheProvider(normalCacheConn);
 
-            const cachedTableCacheConn = createConnection(getConnectionOptions());
-            handleDisconnect(normalCacheConn);
+            const cachedTableCacheConn = new ConnectionWrapper(getConnectionOptions());
             this.cachedTableCacheProvider = new CachedTableCacheProvider(cachedTableCacheConn);
         }
     }

--- a/api/app/core/cache/CacheProvider.ts
+++ b/api/app/core/cache/CacheProvider.ts
@@ -4,6 +4,6 @@ export interface CacheOption {
 }
 
 export interface CacheProvider {
-    set(key: string, value: any, options?: CacheOption): void;
-    get(key: string): any;
+    set(key: string, value: any, options?: CacheOption): Promise<any>;
+    get(key: string): Promise<any>;
 }

--- a/api/app/core/cache/CachedTableCacheProvider.ts
+++ b/api/app/core/cache/CachedTableCacheProvider.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
-import { Connection } from "mysql2";
+import { OkPacket, ResultSetHeader, RowDataPacket } from "mysql2";
+import { ConnectionWrapper } from "../../utils/db";
 import { CacheOption, CacheProvider } from "./CacheProvider";
 
 const logger = consola.withTag('cached-table-cache')
@@ -7,44 +8,38 @@ const logger = consola.withTag('cached-table-cache')
 export default class CachedTableCacheProvider implements CacheProvider {
 
     constructor(
-        private readonly conn: Connection
+        private readonly conn: ConnectionWrapper
     ) {}
     
-    async set(key: string, value: string, options?: CacheOption): Promise<void> {
+    async set<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
+        key: string, value: string, options?: CacheOption
+    ) {
         const EX = options?.EX || -1;
         const sql = `INSERT INTO cached_table_cache(cache_key, cache_value, expires) 
         VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE cache_value = VALUES(cache_value), expires = VALUES(expires);`;
 
-        return new Promise((resolve, reject) => {
-            this.conn.query(sql, [key, value, EX], (err, rows) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            });
-        });
+        return this.conn.query<T>(sql, [key, value, EX]);
     }
 
-    async get(key: string): Promise<any> {
+    async get(key: string) {
         const sql = `SELECT *, DATE_ADD(updated_at, INTERVAL expires SECOND) AS expired_at
         FROM cached_table_cache
         WHERE cache_key = ? AND ((expires = -1) OR (DATE_ADD(updated_at, INTERVAL expires SECOND) >= CURRENT_TIME))
         LIMIT 1;`;
 
-        return new Promise((resolve, reject) => {
-            this.conn.query(sql, [key], (err, rows: any) => {
-                if (err) {
-                    reject(err);
+        return new Promise(async (resolve, reject) => {
+            try {
+                const res = await this.conn.query(sql, [key]);
+                const rows: any = res?.result;
+                if (Array.isArray(rows) && rows.length >= 1) {
+                    resolve(rows[0]?.cache_value);
                 } else {
-                    if (Array.isArray(rows) && rows.length >= 1) {
-                        resolve(rows[0]?.cache_value);
-                    } else {
-                        resolve(null);
-                    }
+                    resolve(null);
                 }
-            });
+            } catch (err) {
+                reject(err);
+            }
         });
     }
 }

--- a/api/app/utils/db.ts
+++ b/api/app/utils/db.ts
@@ -1,6 +1,5 @@
-import { PoolOptions } from "mysql2/typings/mysql";
-import consola from "consola";
-import { Connection, createConnection } from "mysql2";
+import consola, { Consola } from "consola";
+import { PoolOptions, Connection, createConnection, RowDataPacket, OkPacket, ResultSetHeader, FieldPacket, QueryError, Query } from "mysql2";
 
 const DEFAULT_TIDB_SERVER_PORT = '4000';
 
@@ -28,15 +27,60 @@ export function getConnectionOptions(options?: PoolOptions) {
     return Object.assign(defaultOptions, options);
 }
 
-export function handleDisconnect(client: Connection) {
-    client.on('error', function (err: any) {
-      if (!err.fatal) return;
-      if (err.code !== 'PROTOCOL_CONNECTION_LOST') throw err;
-  
-      console.error('> Re-connecting lost MySQL connection: ' + err.stack);
-  
-      const mysqlClient = createConnection(client.config);
-      handleDisconnect(mysqlClient);
-      mysqlClient.connect();
-    });
-};
+export interface QueryResponse<T> {
+    result: T;
+    fields: FieldPacket[];
+}
+
+export class ConnectionWrapper {
+    public conn: Connection;
+    private log: Consola;
+
+    constructor(options: PoolOptions) {
+        this.log = consola.withTag('db-conn');
+        this.conn = createConnection(options);
+        this.conn.on('error', (err: any) => {
+            if (!err.fatal) return;
+            if (err.code !== 'PROTOCOL_CONNECTION_LOST') throw err;
+
+            this.log.warn(`Database server connection lost, trying to reconnect.`);
+            const newConn = createConnection(this.conn.config);
+            newConn.connect();
+            this.conn = newConn;
+        });
+    }
+
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
+        sql: string,
+        values: any | any[] | { [param: string]: any }
+    ): Promise<QueryResponse<T>> {
+        return new Promise((resolve, reject) => {
+            this.conn.query<T>(sql, values, (err: QueryError | null, result, fields) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve({
+                        result, fields
+                    });
+                }
+            });
+        });
+    }
+    
+    execute<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
+        sql: string,
+    ): Promise<QueryResponse<T>> {
+        return new Promise((resolve, reject) => {
+            this.conn.execute<T>(sql, (err: QueryError | null, result, fields) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve({
+                        result, fields
+                    });
+                }
+            });
+        });
+    }
+
+}

--- a/api/scripts/calc-hot-collections/index.ts
+++ b/api/scripts/calc-hot-collections/index.ts
@@ -9,8 +9,7 @@ import GHEventService from "../../app/services/GHEventService";
 import UserService from "../../app/services/UserService";
 import schedule from 'node-schedule';
 import sleep from "../../app/utils/sleep";
-import { getConnectionOptions, handleDisconnect } from "../../app/utils/db";
-import { createConnection } from "mysql2";
+import { ConnectionWrapper, getConnectionOptions } from "../../app/utils/db";
 
 const COLLECTIONS_RANKING_QUERY = 'collection-stars-month-rank';
 
@@ -34,8 +33,7 @@ const interval = parseInt(process.env.CALC_HOT_COLLECTIONS_INTERVAL || '30');
 logger.info(`Execute calc hot collections job according cron expression: ${cron}`);
 schedule.scheduleJob(cron, async () => {
     // Init TiDB client.
-    const conn = createConnection(getConnectionOptions());
-    handleDisconnect(conn);
+    const conn = new ConnectionWrapper(getConnectionOptions());
 
     // Init TiDB Query Executor.
     const queryExecutor = new TiDBQueryExecutor(getConnectionOptions({

--- a/api/scripts/sync-nginx-log/index.ts
+++ b/api/scripts/sync-nginx-log/index.ts
@@ -1,12 +1,11 @@
 import consola from 'consola';
 import * as dotenv from "dotenv";
 import { DateTime } from 'luxon';
-import { createConnection } from 'mysql2';
 import path from 'path';
 import { Tail } from 'tail';
 import { URL } from 'url';
 import { BatchLoader } from '../../app/core/BatchLoader';
-import { getConnectionOptions, handleDisconnect } from '../../app/utils/db';
+import { ConnectionWrapper, getConnectionOptions } from '../../app/utils/db';
 
 // The default access log format of nginx.
 // Reference: http://nginx.org/en/docs/http/ngx_http_log_module.html
@@ -52,8 +51,7 @@ async function main () {
     }
 
     // Init TiDB client.
-    const conn = createConnection(getConnectionOptions());
-    handleDisconnect(conn);
+    const conn = new ConnectionWrapper(getConnectionOptions());
 
     // Start read access log as stream.
     const sql = 'INSERT IGNORE INTO access_logs(remote_addr, status_code, request_path, request_params, requested_at) VALUES ?';

--- a/api/scripts/sync-repos/worker.ts
+++ b/api/scripts/sync-repos/worker.ts
@@ -4,8 +4,7 @@ import { Factory } from "generic-pool"
 import { Octokit } from "octokit"
 import { throttling } from "@octokit/plugin-throttling";
 import { BatchLoader } from "../../app/core/BatchLoader";
-import { Connection, createConnection } from "mysql2";
-import { getConnectionOptions } from "../../app/utils/db";
+import { ConnectionWrapper, getConnectionOptions } from "../../app/utils/db";
 
 export const CustomOctokit = Octokit.plugin(throttling);
 export const SYMBOL_TOKEN = Symbol('PERSONAL_TOKEN');
@@ -32,7 +31,7 @@ export function eraseToken (value: string | undefined): string {
 
 export interface JobWorker {
   logger: Consola;
-  conn: Connection;
+  conn: ConnectionWrapper;
   octokit: Octokit;
   repoLoader: BatchLoader;
   repoLangLoader: BatchLoader;
@@ -88,7 +87,7 @@ export class WorkerFactory implements Factory<JobWorker> {
         });
 
         // Init TiDB client.
-        const conn = createConnection(getConnectionOptions());
+        const conn = new ConnectionWrapper(getConnectionOptions());
 
         // Init worker.
         const worker = {


### PR DESCRIPTION
Some components of the API-Server use a single database connection. If the client disconnected with the database server, the service will be unavailable and throw the following errors in the program.

```
Error: Connection lost: The server closed the connection.
    at Socket.<anonymous> (xxx/ossinsight/api/node_modules/.pnpm/mysql2@2.3.3/node_modules/mysql2/lib/connection.js:101:31)
    at Socket.emit (node:events:527:28)
    at TCP.<anonymous> (node:net:709:12)
Emitted 'error' event on Connection instance at:
    at Connection._notifyError (xxx/ossinsight/api/node_modules/.pnpm/mysql2@2.3.3/node_modules/mysql2/lib/connection.js:236:12)
    at Socket.<anonymous> (xxxx/ossinsight/api/node_modules/.pnpm/mysql2@2.3.3/node_modules/mysql2/lib/connection.js:107:12)
    at Socket.emit (node:events:527:28)
    at TCP.<anonymous> (node:net:709:12) {
  fatal: true,
  code: 'PROTOCOL_CONNECTION_LOST'
}
```

As the methods mentioned in the issue https://github.com/mysqljs/mysql/issues/431, we can re-establish a new connection when encountering the `PROTOCOL_CONNECTION_LOST` error to replace the old connection.

We can create a wrapper class to host the database connection so that we can automatically reconnect.

```Typescript
export class ConnectionWrapper {
    public conn: Connection;
    private log: Consola;

    constructor(options: PoolOptions) {
        this.log = consola.withTag('db-conn');
        this.conn = createConnection(options);
        this.conn.on('error', (err: any) => {
            if (!err.fatal) return;
            if (err.code !== 'PROTOCOL_CONNECTION_LOST') throw err;

            this.log.warn(`Database server connection lost, trying to reconnect.`);
            const newConn = createConnection(this.conn.config);
            newConn.connect();
            this.conn = newConn;
        });
    }
```

We do not use the database connection pool for re-connection, because the reuse connected after using the connection pool will be limited, and we always need to call the `getConnection()` first. If there are too many requests, it will cause the query to queue up.

