### PR TITLE
add milvus in opensource and go-database

### DIFF
--- a/backend/meta/collections/10043.go-database.yml
+++ b/backend/meta/collections/10043.go-database.yml
@@ -31,3 +31,4 @@ items:
   - uber/aresdb
   - FerretDB/FerretDB
   - polarsignals/frostdb
+  - milvus-io/milvus

--- a/backend/meta/collections/2.open-source-database.yml
+++ b/backend/meta/collections/2.open-source-database.yml
@@ -35,3 +35,4 @@ items:
   - postgres/postgres
   - duckdb/duckdb
   - apache/shardingsphere
+  - milvus-io/milvus


### PR DESCRIPTION
Add milvus in opensource and go-database category.
