### PR TITLE
Upgrade mysql2 to support ssl_mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - ENABLE_CACHE=0
 
   web:
-    image: hooopo/ossinsight-fe:latest
+    image: hooopo/ossinsight-web:latest
     restart: always
     build:
       context: ./web

--- a/etl/Gemfile
+++ b/etl/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 # Use mysql as the database for Active Record
-gem 'mysql2', '~> 0.5'
+gem 'mysql2', '~> 0.5.4'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets

--- a/etl/Gemfile.lock
+++ b/etl/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     msgpack (1.4.2)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
-    mysql2 (0.5.3)
+    mysql2 (0.5.4)
     naught (1.1.0)
     nio4r (2.5.8)
     nokogiri (1.12.5)


### PR DESCRIPTION
part of #970

0.5.3 doesn't support tls when working with mariadb client which is the case in docker image.
See issue here: https://github.com/brianmario/mysql2/issues/1094

Signed-off-by: Xiaoguang Sun <sunxiaoguang@gmail.com>