### PR TITLE
collection: add VAST to security tool collection

### DIFF
--- a/etl/meta/collections/10051.security-tool.yml
+++ b/etl/meta/collections/10051.security-tool.yml
@@ -44,3 +44,4 @@ items:
   - gamelinux/passivedns
   - lanmaster53/recon-ng
   - jeremylong/DependencyCheck
+  - tenzir/vast


### PR DESCRIPTION
This PR adds VAST to the security tool list.
