### PR TITLE
ai(prompt): prompt ai to set table name as prefix to avoid ambiguous column name

### DIFF
--- a/packages/api-server/src/plugins/services/bot-service/template/GenerateAnswerPromptTemplate.ts
+++ b/packages/api-server/src/plugins/services/bot-service/template/GenerateAnswerPromptTemplate.ts
@@ -75,7 +75,7 @@ Answer {
 }
 
 ---
-Let's think step by step, use best practice of writing SQL, use common table expression, window function if necessary, if there is no specific repo, scan all repos, generate a answer.json file to answer the question: ${question}?
+Let's think step by step, use best practice of writing SQL(add table name as prefix to column if necessary), use common table expression, window function if necessary, scan all repos if there is no specific repo, generate a answer.json file to answer the question: ${question}?
 ---
 answer.json
 ---


### PR DESCRIPTION
**What problem does this PR solve?**

Wrong:
```sql
select repo_name from github_events ge inner join github_repos gr ....
```


Correct:
```sql
select ge.repo_name from github_events ge inner join github_repos gr ....
```

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #xxx

Problem Summary:

**What is changed and how it works?**