### PR TITLE
ETL: add approximate nearest neighbor library collection

### DIFF
--- a/etl/meta/collections/10070.Approximate-Nearest-Neighbor-library.yml
+++ b/etl/meta/collections/10070.Approximate-Nearest-Neighbor-library.yml
@@ -1,0 +1,21 @@
+id: 10070
+name: approximate nearest neighbor library
+items:
+  - spotify/annoy
+  - ryanrhymes/panns
+  - vioshyvo/mrpt
+  - pixelogik/NearPy
+  - aaalgo/kgraph
+  - nmslib/nmslib
+  - nmslib/hnswlib
+  - lyst/rpforest
+  - facebookresearch/faiss
+  - ekzhu/datasketch
+  - lmcinnes/pynndescent
+  - yahoojapan/NGT
+  - microsoft/SPTAG
+  - kakao/n2
+  - google-research/google-research/tree/master/scann
+  - alexklibisz/elastiknn
+  - opensearch-project/k-NN
+  - microsoft/diskann


### PR DESCRIPTION
<!--

Thank you for contributing to OSS Insight!

PR Title Format:

Please add the scope of pull request as the title prefix like:

```
<scope>: what's changed.
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add pingcap/tidb repo to open source database collection
```
-->

**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

This pr is to add a new collection of approximate nearest neighbor library on Github, which can be used to search approximate nearest neighbor of high dimension vector in many areas.
 I found ossinsight collection have no such an entry and organize the collection based on [ann-benchmark](https://github.com/erikbern/ann-benchmarks) that contains some tools to benchmark various implementations of approximate nearest neighbor (ANN) search for different metrics.