### PR TITLE
prompt-manager: do not escape for prompt template

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,6 @@
     "dev:sync-users": "ts-node scripts/sync-users/index.ts",
     "gen:api-documentation": "ts-node scripts/gen-openapi/index.ts",
     "gen:schema-ts": "json2ts params.schema.json params.schema.d.ts",
-    "postinstall": "npm run gen:schema-ts && npm run gen:api-documentation",
     "server": "node ./dist/index.js",
     "server:cache-gc": "node ./dist/scripts/cache-gc/index.js",
     "server:calc-hot-collections": "node ./dist/scripts/calc-hot-collections/index.js",

--- a/packages/api-server/src/plugins/config/prompt-template-manager.ts
+++ b/packages/api-server/src/plugins/config/prompt-template-manager.ts
@@ -54,7 +54,7 @@ export class PromptTemplateManager {
     }
 
     public async loadTemplateFile(promptTemplateDir: string, promptPath: string) {
-        this.logger.info(`Loading prompt template from ${promptPath}`);
+        this.logger.info(`Loading prompt template from ${promptPath} for ${promptTemplateDir}`);
         const promptTemplate = fs.readFileSync(promptPath, "utf-8");
         this.promptTemplates.set(promptTemplateDir, promptTemplate);
     }
@@ -65,6 +65,8 @@ export class PromptTemplateManager {
         if (!promptTemplate) {
             return null;
         }
-        return mustache.render(promptTemplate, context);
+        return mustache.render(promptTemplate, context, {}, {
+            escape: (text) => text
+        });
     }
 }


### PR DESCRIPTION
**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #xxx

Problem Summary:

> All variables are HTML-escaped by default. If you want to render unescaped HTML, use the triple mustache: {{{name}}}. You can also use & to unescape a variable.
> 
> If you'd like to change HTML-escaping behavior globally (for example, to template non-HTML formats), you can override Mustache's escape function. For example, to disable all escaping: Mustache.escape = function(text) {return text;};.
> 

https://github.com/janl/mustache.js#variables

**What is changed and how it works?**