### PR TITLE
config: Add Qwik to Javascript frameworks

### DIFF
--- a/etl/meta/collections/10005.javascript-framework.yml
+++ b/etl/meta/collections/10005.javascript-framework.yml
@@ -31,3 +31,4 @@ items:
   - solidjs/solid
   - ionic-team/stencil
   - jquery/jquery
+  - BuilderIO/qwik


### PR DESCRIPTION
Adds qwik framework to the list of javascript frameworks!

In the same repo, we also have QwikCity the equivalent to SvelteKit, or Solid Start, or Next, can I add the same repo to several sections?