### PR TITLE
etl: added calcom/cal.com to business-management collection

### DIFF
--- a/etl/meta/collections/10072.business-management.yml
+++ b/etl/meta/collections/10072.business-management.yml
@@ -13,3 +13,4 @@ items:
   - ledger/ledger
   - odoo/odoo
   - FrontAccountingERP/FA
+  - calcom/cal.com


### PR DESCRIPTION
This PR adds the repository calcom/cal.com to the business-management collection. 