### PR TITLE
explorer: add retry logic for openai API

### DIFF
--- a/packages/api-server/src/plugins/services/bot-service/index.ts
+++ b/packages/api-server/src/plugins/services/bot-service/index.ts
@@ -146,8 +146,11 @@ export class BotService {
                 // Convert only-data-event stream to token stream.
                 const tokenStream = new stream.Transform({
                     transform(chunk, encoding, callback) {
-                        this.push(chunk);
-                        tokens.push(chunk);
+                        // Notice: Skip undefined chunk.
+                        if (chunk) {
+                            this.push(chunk);
+                            tokens.push(chunk);
+                        }
                         callback();
                     },
                 });
@@ -158,7 +161,7 @@ export class BotService {
                     // The data is start with "data: " prefix, we need to remove it to get a JSON string.
                     // In same times, there are multiple JSONs return in one response.
                     const responseText = data?.toString();
-                    const tokenJSONs = responseText?.slice(6)?.split("\n\ndata: ");
+                    const tokenJSONs = responseText?.slice(6)?.split("\n\ndata: ").filter(Boolean);
                     if (!Array.isArray(tokenJSONs) || tokenJSONs.length === 0) {
                         return;
                     }
@@ -168,8 +171,11 @@ export class BotService {
                             if (tokenJSON === "[DONE]\n\n") {
                                 tokenStream.end();
                             } else {
+                                // Notice: Skip undefined token.
                                 const token = JSON.parse(tokenJSON)?.choices?.[0]?.text;
-                                tokenStream.write(token);
+                                if (token) {
+                                    tokenStream.write(token);
+                                }
                             }
                         }
                     } catch (err: any) {

--- a/packages/api-server/src/utils/sleep.ts
+++ b/packages/api-server/src/utils/sleep.ts
@@ -1,0 +1,1 @@
+export default (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
<!--

Thank you for contributing to OSS Insight!

PR Title Format:

Please add the scope of pull request as the title prefix like:

```
<scope>: what's changed.
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add pingcap/tidb repo to open source database collection
```
-->

**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #xxx

Problem Summary:

Handle the following error when the data explorer access OpenAI API, and add retry logic for it

> aborted

> Request failed with status code 429

> The \"chunk\" argument must be of type string or an instance of Buffer or Uint8Array. Received undefined

**What is changed and how it works?**