### PR TITLE
Add meshery/meshery to the X as Code sub-category

### DIFF
--- a/etl/meta/collections/10068.x-as-code.yml
+++ b/etl/meta/collections/10068.x-as-code.yml
@@ -11,6 +11,7 @@ items:
   - aws/aws-cdk
   - crossplane/crossplane
   - kubevela/kubevela
+  - meshery/meshery
   
 # The relationship between X as Code and Configuration management tools is the following:
 # 1. The X as Code is a subset of Configuration Management.


### PR DESCRIPTION
Meshery falls into the X as Code in terms of the designs/patterns it uses to manage infrastructure. See the emerging https://meshery.io/catalog for example designs/patterns.

<!--

Thank you for contributing to OSS Insight!

PR Title Format:

Please add the scope of pull request as the title prefix like:

```
<scope>: what's changed.
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add pingcap/tidb repo to open source database collection
```
-->

**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #xxx

Problem Summary:

**What is changed and how it works?**