### PR TITLE
config: add komodorio/helm-dashboard repo to open source database collection

### DIFF
--- a/etl/meta/collections/10063.kubernetes-tooling.yml
+++ b/etl/meta/collections/10063.kubernetes-tooling.yml
@@ -22,3 +22,4 @@ items:
   - helm/helm
   - opencost/opencost
   - kubeshop/monokle
+  - komodorio/helm-dashboard


### PR DESCRIPTION
Helm-Dashboard is one of the most popular new OSS K8s repos 