### PR TITLE
explorer: add trigger batch refresh API

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "packages/feeds-server"
   ],
   "scripts": {
-    "prepare": "husky install",
-    "postinstall": "cd web && npm install"
+    "prepare": "husky install"
   },
   "devDependencies": {
     "husky": "^8.0.1",

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -39,6 +39,7 @@
     "@octokit/rest": "^19.0.5",
     "JSONStream": "^1.3.5",
     "axios": "^0.27.2",
+    "async": "^3.2.4",
     "bullmq": "^3.4.1",
     "fastify": "^4.0.0",
     "fastify-auth0-verify": "^1.0.0",
@@ -62,6 +63,7 @@
     "yaml": "^2.1.3"
   },
   "devDependencies": {
+    "@types/async": "^3.2.15",
     "@fastify/type-provider-json-schema-to-ts": "^2.1.1",
     "@types/chance": "^1.1.3",
     "@types/generic-pool": "^3.1.11",

--- a/packages/api-server/src/plugins/services/explorer-service/types.ts
+++ b/packages/api-server/src/plugins/services/explorer-service/types.ts
@@ -28,6 +28,8 @@ export interface Question {
   chart?: RecommendedChart | null;
   answer?: Answer | null;
   answerSummary?: AnswerSummary;
+  batchJobId: string | null;
+  needReview: boolean;
   recommended: boolean;
   createdAt: DateTime;
   requestedAt?: DateTime | null;

--- a/packages/api-server/src/routes/explorer/questions/index.ts
+++ b/packages/api-server/src/routes/explorer/questions/index.ts
@@ -28,9 +28,9 @@ export const newQuestionHandler: FastifyPluginAsyncJsonSchemaToTs = async (app):
     preValidation: app.authenticate
   }, async function (req, reply) {
     const { explorerService } = app;
-
     const conn = await this.mysql.getConnection();
 
+    // Get user id from auth0.
     const { sub, metadata } = parseAuth0User(req.user as Auth0User);
     const userId = await app.userService.findOrCreateUserByAccount(
       { ...metadata, sub },
@@ -40,7 +40,7 @@ export const newQuestionHandler: FastifyPluginAsyncJsonSchemaToTs = async (app):
     const { question: questionTitle, ignoreCache } = req.body;
 
     try {
-      const question = await explorerService.newQuestion(conn, userId, metadata?.github_login, questionTitle, ignoreCache);
+      const question = await explorerService.newQuestion(userId, questionTitle, ignoreCache, false, false, null, conn);
 
       // Prepare question async.
       if (!question.hitCache) {

--- a/packages/api-server/src/routes/explorer/questions/recommend/batchRefresh/index.ts
+++ b/packages/api-server/src/routes/explorer/questions/recommend/batchRefresh/index.ts
@@ -1,0 +1,36 @@
+import {FastifyPluginAsyncJsonSchemaToTs} from "@fastify/type-provider-json-schema-to-ts";
+import {Auth0User, parseAuth0User} from "../../../../../plugins/services/user-service/auth0";
+
+const schema = {
+  summary: 'Refresh recommend questions',
+  description: 'Refresh recommended questions in batch.',
+  tags: ['explorer']
+};
+
+export const refreshRecommendQuestionsHandler: FastifyPluginAsyncJsonSchemaToTs = async (app): Promise<void> => {
+  app.post('/', {
+    schema,
+    // @ts-ignore
+    preValidation: app.authenticate
+  }, async function (req, reply) {
+    // Only trusted users can trigger this.
+    const { sub, metadata } = parseAuth0User(req.user as Auth0User);
+    const userId = await app.userService.findOrCreateUserByAccount(
+      { ...metadata, sub },
+      req.headers.authorization
+    );
+    await app.explorerService.checkIfTrustedUsersOrError(userId);
+
+    // Trigger refresh.
+    app.explorerService.refreshRecommendQuestions().then(() => {
+      app.log.info('Refresh recommend questions success.')
+    }).catch((err: any) => {
+      app.log.error(err, `Failed to refresh recommend questions: ${err.message}`);
+    });
+    reply.status(200).send({
+      message: 'Trigger success.'
+    });
+  });
+}
+
+export default refreshRecommendQuestionsHandler;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,7 @@ importers:
       '@octokit/graphql': ^5.0.4
       '@octokit/plugin-throttling': ^4.3.2
       '@octokit/rest': ^19.0.5
+      '@types/async': ^3.2.15
       '@types/chance': ^1.1.3
       '@types/generic-pool': ^3.1.11
       '@types/glob': ^8.0.0
@@ -147,6 +148,7 @@ importers:
       '@types/node': ^18.0.0
       '@types/ws': ^8.5.3
       JSONStream: ^1.3.5
+      async: ^3.2.4
       axios: ^0.27.2
       bullmq: ^3.4.1
       chance: ^1.1.9
@@ -202,6 +204,7 @@ importers:
       '@octokit/plugin-throttling': 4.3.2_@octokit+core@4.1.0
       '@octokit/rest': 19.0.5
       JSONStream: 1.3.5
+      async: 3.2.4
       axios: 0.27.2
       bullmq: 3.4.1
       fastify: 4.10.2
@@ -226,6 +229,7 @@ importers:
       yaml: 2.1.3
     devDependencies:
       '@fastify/type-provider-json-schema-to-ts': 2.1.1_hxq56dazpdjlc3paj7oyucwelq
+      '@types/async': 3.2.16
       '@types/chance': 1.1.3
       '@types/generic-pool': 3.1.11
       '@types/glob': 8.0.0


### PR DESCRIPTION
Re-execute the recommended question in batch. After re-execution, it needs to be manually approved to reset it as a recommended question. (Because the result of AI returns is not stable, it is necessary to manually confirm whether the result after re-execution is still satisfactory.)

To get the questions need to review, can execute the following SQL:

```sql
SELECT batch_job_id, CONCAT('https://ossinsight.io/explore/?id=', BIN_TO_UUID(eq.id)) AS link, user_id, title, status, error_type, eq.created_at, GROUP_CONCAT(eqt.label) AS labels, answer
FROM explorer_questions eq
LEFT JOIN explorer_question_tag_rel eqtr ON eq.id = eqtr.question_id
LEFT JOIN explorer_question_tags eqt ON eqt.id = eqtr.tag_id
WHERE
    recommended = 0
    AND need_review = 1
GROUP BY eq.id
ORDER BY created_at DESC
```

In addition, we can distinguish batch operations at different times through a `batch_job_id` field, so that we can monitor the changes in the ability of AI to solve the problem. @sykp241095 