### PR TITLE
query: avoid to use event-month

### DIFF
--- a/configs/queries/analyze-issue-open-to-closed/template.sql
+++ b/configs/queries/analyze-issue-open-to-closed/template.sql
@@ -1,6 +1,6 @@
 with issue_with_closed_at as (
     select
-        number, DATE_FORMAT(created_at, '%Y-%m-01') AS event_month, created_at as closed_at
+        number, DATE_FORMAT(created_at, '%Y-%m-01') AS t_month, created_at as closed_at
     from
         github_events ge
     where
@@ -21,52 +21,52 @@ with issue_with_closed_at as (
         and repo_id = 41986369
 ), tdiff as (
     select
-        DATE_FORMAT(event_month, '%Y-%m-01') AS event_month,
+        DATE_FORMAT(t_month, '%Y-%m-01') AS t_month,
         (UNIX_TIMESTAMP(iwc.closed_at) - UNIX_TIMESTAMP(iwo.opened_at)) as diff
     from
         issue_with_opened_at iwo
         join issue_with_closed_at iwc on iwo.number = iwc.number and iwc.closed_at > iwo.opened_at
 ), tdiff_with_rank as (
     select
-        tdiff.event_month,
+        tdiff.t_month,
         diff  / 60 / 60 as diff,
-        ROW_NUMBER() over (partition by tdiff.event_month order by diff) as r,
-        count(*) over (partition by tdiff.event_month) as cnt,
-        first_value(diff / 60 / 60) over (partition by tdiff.event_month order by diff) as p0,
-        first_value(diff / 60 / 60)  over (partition by tdiff.event_month order by diff desc) as p100
+        ROW_NUMBER() over (partition by tdiff.t_month order by diff) as r,
+        count(*) over (partition by tdiff.t_month) as cnt,
+        first_value(diff / 60 / 60) over (partition by tdiff.t_month order by diff) as p0,
+        first_value(diff / 60 / 60)  over (partition by tdiff.t_month order by diff desc) as p100
     from tdiff
 ), tdiff_p25 as (
     select
-        event_month, diff as p25
+        t_month, diff as p25
     from
         tdiff_with_rank tr
     where
         r = round(cnt * 0.25)
 ), tdiff_p50 as (
     select
-        event_month, diff as p50
+        t_month, diff as p50
     from
         tdiff_with_rank tr
     where
         r = round(cnt * 0.5)
 ), tdiff_p75 as (
     select
-        event_month, diff as p75
+        t_month, diff as p75
     from
         tdiff_with_rank tr
     where
         r = round(cnt * 0.75)
 )
 select
-    distinct tr.event_month,
+    distinct tr.t_month AS event_month,
     p0,
     p25,
     p50,
     p75,
     p100
 from tdiff_with_rank tr
-left join tdiff_p25 p25 on tr.event_month = p25.event_month
-left join tdiff_p50 p50 on tr.event_month = p50.event_month
-left join tdiff_p75 p75 on tr.event_month = p75.event_month
+left join tdiff_p25 p25 on tr.t_month = p25.t_month
+left join tdiff_p50 p50 on tr.t_month = p50.t_month
+left join tdiff_p75 p75 on tr.t_month = p75.t_month
 order by 1
 ;

--- a/configs/queries/analyze-issue-open-to-first-responded/template.sql
+++ b/configs/queries/analyze-issue-open-to-first-responded/template.sql
@@ -1,75 +1,76 @@
-with issue_with_first_responed_at as (
-    select
-        number, min(date_format(created_at, '%Y-%m-01')) as t_month, min(created_at) as first_responed_at
-    from
+WITH issue_with_first_responded_at AS (
+    SELECT
+        number, MIN(DATE_FORMAT(created_at, '%Y-%m-01')) AS t_month, MIN(created_at) AS first_responded_at
+    FROM
         github_events ge
-    where
+    WHERE
         repo_id = 41986369
-        and ((type = 'IssueCommentEvent' and action = 'created') or (type = 'IssuesEvent' and action = 'closed'))
+        AND ((type = 'IssueCommentEvent' AND action = 'created') OR (type = 'IssuesEvent' AND action = 'closed'))
         -- Exclude Bots
-        -- and actor_login not like '%bot%'
-        -- and actor_login not in (select login from blacklist_users bu)
-    group by 1
-), issue_with_opened_at as (
-    select
-        number, created_at as opened_at
-    from
+        -- AND actor_login NOT LIKE '%bot%'
+        -- AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+    GROUP BY 1
+), issue_with_opened_at AS (
+    SELECT
+        number, created_at AS opened_at
+    FROM
         github_events ge
-    where
+    WHERE
         repo_id = 41986369
-        and type = 'IssuesEvent'
-        and action = 'opened'
+        AND type = 'IssuesEvent'
+        AND action = 'opened'
         -- Exclude Bots
-        -- and actor_login not like '%bot%'
-        -- and actor_login not in (select login from blacklist_users bu)
-), tdiff as (
-    select
+        -- AND actor_login NOT LIKE '%bot%'
+        -- AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+), tdiff AS (
+    SELECT
         t_month,
-        (UNIX_TIMESTAMP(iwfr.first_responed_at) - UNIX_TIMESTAMP(iwo.opened_at)) as diff
-    from
+        (UNIX_TIMESTAMP(iwfr.first_responded_at) - UNIX_TIMESTAMP(iwo.opened_at)) AS diff
+    FROM
         issue_with_opened_at iwo
-        join issue_with_first_responed_at iwfr on iwo.number = iwfr.number and iwfr.first_responed_at > iwo.opened_at
-), tdiff_with_rank as (
-    select
+        JOIN issue_with_first_responded_at iwfr ON iwo.number = iwfr.number AND iwfr.first_responded_at > iwo.opened_at
+), tdiff_with_rank AS (
+    SELECT
         tdiff.t_month,
-        diff  / 60 / 60 as diff,
-        ROW_NUMBER() over (partition by tdiff.t_month order by diff) as r,
-        count(*) over (partition by tdiff.t_month) as cnt,
-        first_value(diff / 60 / 60) over (partition by tdiff.t_month order by diff) as p0,
-        first_value(diff / 60 / 60)  over (partition by tdiff.t_month order by diff desc) as p100
-    from tdiff
-), tdiff_p25 as (
-    select
-        t_month, diff as p25
-    from
+        diff  / 60 / 60 AS diff,
+        ROW_NUMBER() OVER (PARTITION BY tdiff.t_month ORDER BY diff) AS r,
+        COUNT(*) OVER (PARTITION BY tdiff.t_month) AS cnt,
+        FIRST_VALUE(diff / 60 / 60) OVER (PARTITION BY tdiff.t_month ORDER BY diff) AS p0,
+        FIRST_VALUE(diff / 60 / 60)  OVER (PARTITION BY tdiff.t_month ORDER BY diff DESC) AS p100
+    FROM tdiff
+), tdiff_p25 AS (
+    SELECT
+        t_month, diff AS p25
+    FROM
         tdiff_with_rank tr
-    where
-        r = round(cnt * 0.25)
-), tdiff_p50 as (
-    select
-        t_month, diff as p50
-    from
+    WHERE
+        r = ROUND(cnt * 0.25)
+), tdiff_p50 AS (
+    SELECT
+        t_month, diff AS p50
+    FROM
         tdiff_with_rank tr
-    where
-        r = round(cnt * 0.5)
-), tdiff_p75 as (
-    select
-        t_month, diff as p75
-    from
+    WHERE
+        r = ROUND(cnt * 0.5)
+), tdiff_p75 AS (
+    SELECT
+        t_month, diff AS p75
+    FROM
         tdiff_with_rank tr
-    where
-        r = round(cnt * 0.75)
+    WHERE
+        r = ROUND(cnt * 0.75)
 )
-select
-    distinct tr.t_month AS event_month,
+SELECT
+    tr.t_month AS event_month,
     p0,
     p25,
     p50,
     p75,
     p100
-from tdiff_with_rank tr
-left join tdiff_p25 p25 on tr.t_month = p25.t_month
-left join tdiff_p50 p50 on tr.t_month = p50.t_month
-left join tdiff_p75 p75 on tr.t_month = p75.t_month
-order by 1
+FROM tdiff_with_rank tr
+LEFT JOIN tdiff_p25 p25 ON tr.t_month = p25.t_month
+LEFT JOIN tdiff_p50 p50 ON tr.t_month = p50.t_month
+LEFT JOIN tdiff_p75 p75 ON tr.t_month = p75.t_month
+WHERE r = 1
+ORDER BY event_month
 ;

--- a/configs/queries/analyze-issue-opened-and-closed/template.sql
+++ b/configs/queries/analyze-issue-opened-and-closed/template.sql
@@ -1,6 +1,6 @@
 with issue_closed as (
     select
-        date_format(created_at, '%Y-%m-01') as event_month, count(number) as closed
+        date_format(created_at, '%Y-%m-01') as t_month,count(number) as closed
     from
         github_events ge
     where
@@ -10,7 +10,7 @@ with issue_closed as (
     group by 1
 ), issue_opened as (
     select
-        date_format(created_at, '%Y-%m-01') as event_month, count(number) as opened
+        date_format(created_at, '%Y-%m-01') as t_month, count(number) as opened
     from
         github_events ge
     where
@@ -20,9 +20,11 @@ with issue_closed as (
     group by 1
 )
 select
-    io.event_month, opened, coalesce(closed, 0) as closed
+    io.t_month AS event_month,
+    opened,
+    coalesce(closed, 0) as closed
 from
     issue_opened io
-    join issue_closed ic on io.event_month = ic.event_month
-order by event_month
+    join issue_closed ic on io.t_month = ic.t_month
+order by t_month
 ;

--- a/configs/queries/analyze-issue-opened-and-closed/template.sql
+++ b/configs/queries/analyze-issue-opened-and-closed/template.sql
@@ -1,30 +1,30 @@
-with issue_closed as (
-    select
-        date_format(created_at, '%Y-%m-01') as t_month,count(number) as closed
-    from
+WITH issue_closed AS (
+    SELECT
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,COUNT(number) AS closed
+    FROM
         github_events ge
-    where
+    WHERE
         type = 'IssuesEvent'
-        and action = 'closed'
-        and repo_id = 41986369
-    group by 1
-), issue_opened as (
-    select
-        date_format(created_at, '%Y-%m-01') as t_month, count(number) as opened
-    from
+        AND action = 'closed'
+        AND repo_id = 41986369
+    GROUP BY 1
+), issue_opened AS (
+    SELECT
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month, COUNT(number) AS opened
+    FROM
         github_events ge
-    where
+    WHERE
         type = 'IssuesEvent'
-        and action = 'opened'
-        and repo_id = 41986369
-    group by 1
+        AND action = 'opened'
+        AND repo_id = 41986369
+    GROUP BY 1
 )
-select
+SELECT
     io.t_month AS event_month,
     opened,
-    coalesce(closed, 0) as closed
-from
+    COALESCE(closed, 0) AS closed
+FROM
     issue_opened io
-    join issue_closed ic on io.t_month = ic.t_month
-order by t_month
+    JOIN issue_closed ic ON io.t_month = ic.t_month
+ORDER BY event_month
 ;

--- a/configs/queries/analyze-people-activities-contribution-rank/template.sql
+++ b/configs/queries/analyze-people-activities-contribution-rank/template.sql
@@ -21,7 +21,8 @@ WITH activity_contribution_last_month AS (
     FROM github_events ge
     WHERE
         repo_id = 41986369
-        AND event_month = DATE_FORMAT(DATE_SUB(DATE_SUB(NOW(), INTERVAL DAYOFMONTH(NOW()) DAY), INTERVAL 1 MONTH), '%Y-%m-01')
+        AND created_at >= DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
+        AND created_at < DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01')
         AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
         AND (
             (type = 'PullRequestEvent' AND action = 'opened') OR

--- a/configs/queries/analyze-people-issue-contribution-rank/template.sql
+++ b/configs/queries/analyze-people-issue-contribution-rank/template.sql
@@ -4,7 +4,7 @@ WITH former_contributors AS (
     WHERE
         repo_id = 41986369
         AND type = 'IssuesEvent' AND action = 'opened'
-        AND event_month < DATE_FORMAT(DATE_SUB(NOW(), INTERVAL DAYOFMONTH(NOW()) DAY), '%Y-%m-01')
+        AND created_at < DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01')
         AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
 ), issue_contribution_last_month AS (
     SELECT actor_login, COUNT(*) AS events

--- a/configs/queries/analyze-pull-request-open-to-merged/template.sql
+++ b/configs/queries/analyze-pull-request-open-to-merged/template.sql
@@ -1,6 +1,6 @@
 with pr_with_merged_at as (
     select
-        number, date_format(created_at, '%Y-%m-01') as event_month, created_at as merged_at
+        number, date_format(created_at, '%Y-%m-01') as t_month, created_at as merged_at
     from
         github_events ge
     where
@@ -24,53 +24,53 @@ with pr_with_merged_at as (
         and repo_id = 41986369
 ), tdiff as (
     select
-        event_month,
+        t_month,
         (UNIX_TIMESTAMP(pwm.merged_at) - UNIX_TIMESTAMP(pwo.opened_at)) as diff
     from
         pr_with_opened_at pwo
         join pr_with_merged_at pwm on pwo.number = pwm.number and pwm.merged_at > pwo.opened_at
 ), tdiff_with_rank as (
     select
-        tdiff.event_month,
+        tdiff.t_month,
         diff  / 60 / 60 as diff,
-        ROW_NUMBER() over (partition by tdiff.event_month order by diff) as r,
-        count(*) over (partition by tdiff.event_month) as cnt,
-        first_value(diff / 60 / 60) over (partition by tdiff.event_month order by diff) as p0,
-        first_value(diff / 60 / 60)  over (partition by tdiff.event_month order by diff desc) as p100
+        ROW_NUMBER() over (partition by tdiff.t_month order by diff) as r,
+        count(*) over (partition by tdiff.t_month) as cnt,
+        first_value(diff / 60 / 60) over (partition by tdiff.t_month order by diff) as p0,
+        first_value(diff / 60 / 60)  over (partition by tdiff.t_month order by diff desc) as p100
     from tdiff
 ), tdiff_p25 as (
     select
-        event_month, diff as p25
+        t_month, diff as p25
     from
         tdiff_with_rank tr
     where
         r = round(cnt * 0.25)
 ), tdiff_p50 as (
     select
-        event_month, diff as p50
+        t_month, diff as p50
     from
         tdiff_with_rank tr
     where
         r = round(cnt * 0.5)
 ), tdiff_p75 as (
     select
-        event_month, diff as p75
+        t_month, diff as p75
     from
         tdiff_with_rank tr
     where
         r = round(cnt * 0.75)
 )
 select
-    distinct tr.event_month,
+    distinct tr.t_month AS event_month,
     p0,
     p25,
     p50,
     p75,
     p100
 from tdiff_with_rank tr
-left join tdiff_p25 p25 on tr.event_month = p25.event_month
-left join tdiff_p50 p50 on tr.event_month = p50.event_month
-left join tdiff_p75 p75 on tr.event_month = p75.event_month
+left join tdiff_p25 p25 on tr.t_month = p25.t_month
+left join tdiff_p50 p50 on tr.t_month = p50.t_month
+left join tdiff_p75 p75 on tr.t_month = p75.t_month
 order by 1
 ;
 

--- a/configs/queries/analyze-pull-request-open-to-merged/template.sql
+++ b/configs/queries/analyze-pull-request-open-to-merged/template.sql
@@ -1,76 +1,76 @@
-with pr_with_merged_at as (
-    select
-        number, date_format(created_at, '%Y-%m-01') as t_month, created_at as merged_at
-    from
+WITH pr_with_merged_at AS (
+    SELECT
+        number, DATE_FORMAT(created_at, '%Y-%m-01') AS t_month, created_at AS merged_at
+    FROM
         github_events ge
-    where
+    WHERE
         type = 'PullRequestEvent'
         -- Considering that some repositoies accept the code of the contributor by closing the PR and push commit directly,
         -- here is not distinguished whether it is the merged event.
         -- See: https://github.com/mongodb/mongo/pulls?q=is%3Apr+is%3Aclosed
-        and action = 'closed'
-        and repo_id = 41986369
-), pr_with_opened_at as (
-    select
-        number, created_at as opened_at
-    from
+        AND action = 'closed'
+        AND repo_id = 41986369
+), pr_with_opened_at AS (
+    SELECT
+        number, created_at AS opened_at
+    FROM
         github_events ge
-    where
+    WHERE
         type = 'PullRequestEvent'
-        and action = 'opened'
+        AND action = 'opened'
         -- Exclude Bots
-        -- and actor_login not like '%bot%'
-        -- and actor_login not in (SELECT login FROM blacklist_users bu)
-        and repo_id = 41986369
-), tdiff as (
-    select
+        -- AND actor_login NOT LIKE '%bot%'
+        -- AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+        AND repo_id = 41986369
+), tdiff AS (
+    SELECT
         t_month,
-        (UNIX_TIMESTAMP(pwm.merged_at) - UNIX_TIMESTAMP(pwo.opened_at)) as diff
-    from
+        (UNIX_TIMESTAMP(pwm.merged_at) - UNIX_TIMESTAMP(pwo.opened_at)) AS diff
+    FROM
         pr_with_opened_at pwo
-        join pr_with_merged_at pwm on pwo.number = pwm.number and pwm.merged_at > pwo.opened_at
-), tdiff_with_rank as (
-    select
+        JOIN pr_with_merged_at pwm ON pwo.number = pwm.number AND pwm.merged_at > pwo.opened_at
+), tdiff_with_rank AS (
+    SELECT
         tdiff.t_month,
-        diff  / 60 / 60 as diff,
-        ROW_NUMBER() over (partition by tdiff.t_month order by diff) as r,
-        count(*) over (partition by tdiff.t_month) as cnt,
-        first_value(diff / 60 / 60) over (partition by tdiff.t_month order by diff) as p0,
-        first_value(diff / 60 / 60)  over (partition by tdiff.t_month order by diff desc) as p100
-    from tdiff
-), tdiff_p25 as (
-    select
-        t_month, diff as p25
-    from
+        diff  / 60 / 60 AS diff,
+        ROW_NUMBER() OVER (PARTITION BY tdiff.t_month ORDER BY diff) AS r,
+        COUNT(*) OVER (PARTITION BY tdiff.t_month) AS cnt,
+        FIRST_VALUE(diff / 60 / 60) OVER (PARTITION BY tdiff.t_month ORDER BY diff) AS p0,
+        FIRST_VALUE(diff / 60 / 60)  OVER (PARTITION BY tdiff.t_month ORDER BY diff DESC) AS p100
+    FROM tdiff
+), tdiff_p25 AS (
+    SELECT
+        t_month, diff AS p25
+    FROM
         tdiff_with_rank tr
-    where
-        r = round(cnt * 0.25)
-), tdiff_p50 as (
-    select
-        t_month, diff as p50
-    from
+    WHERE
+        r = ROUND(cnt * 0.25)
+), tdiff_p50 AS (
+    SELECT
+        t_month, diff AS p50
+    FROM
         tdiff_with_rank tr
-    where
-        r = round(cnt * 0.5)
-), tdiff_p75 as (
-    select
-        t_month, diff as p75
-    from
+    WHERE
+        r = ROUND(cnt * 0.5)
+), tdiff_p75 AS (
+    SELECT
+        t_month, diff AS p75
+    FROM
         tdiff_with_rank tr
-    where
-        r = round(cnt * 0.75)
+    WHERE
+        r = ROUND(cnt * 0.75)
 )
-select
-    distinct tr.t_month AS event_month,
+SELECT
+    tr.t_month AS event_month,
     p0,
     p25,
     p50,
     p75,
     p100
-from tdiff_with_rank tr
-left join tdiff_p25 p25 on tr.t_month = p25.t_month
-left join tdiff_p50 p50 on tr.t_month = p50.t_month
-left join tdiff_p75 p75 on tr.t_month = p75.t_month
-order by 1
+FROM tdiff_with_rank tr
+LEFT JOIN tdiff_p25 p25 ON tr.t_month = p25.t_month
+LEFT JOIN tdiff_p50 p50 ON tr.t_month = p50.t_month
+LEFT JOIN tdiff_p75 p75 ON tr.t_month = p75.t_month
+WHERE r = 1
+ORDER BY event_month
 ;
-

--- a/configs/queries/analyze-pull-requests-size-per-month/template.sql
+++ b/configs/queries/analyze-pull-requests-size-per-month/template.sql
@@ -1,18 +1,18 @@
-SELECT event_month, xs, s, m, l, xl, all_size
+SELECT t_month AS event_month, xs, s, m, l, xl, xxl, all_size
 FROM (
     SELECT
-        event_month,
-        SUM(CASE WHEN (additions + deletions) < 10 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS xs,
-        SUM(CASE WHEN (additions + deletions) >= 10 AND (additions + deletions) < 30 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS s,
-        SUM(CASE WHEN (additions + deletions) >= 30 AND (additions + deletions) < 100 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS m,
-        SUM(CASE WHEN (additions + deletions) >= 100 AND (additions + deletions) < 500 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS l,
-        SUM(CASE WHEN (additions + deletions) >= 500 AND (additions + deletions) < 1000 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS xl,
-        SUM(CASE WHEN (additions + deletions) >= 1000 THEN 1 ELSE 0 END) OVER (PARTITION BY event_month) AS xxl,
-        COUNT(*) OVER (PARTITION BY event_month) AS all_size,
-        ROW_NUMBER() OVER (PARTITION BY event_month) AS row_num
+        t_month,
+        SUM(CASE WHEN (additions + deletions) < 10 THEN 1 ELSE 0 END) OVER(PARTITION BY t_month) AS xs,
+        SUM(CASE WHEN (additions + deletions) >= 10 AND (additions + deletions) < 30 THEN 1 ELSE 0 END) OVER(PARTITION BY t_month) AS s,
+        SUM(CASE WHEN (additions + deletions) >= 30 AND (additions + deletions) < 100 THEN 1 ELSE 0 END) OVER(PARTITION BY t_month) AS m,
+        SUM(CASE WHEN (additions + deletions) >= 100 AND (additions + deletions) < 500 THEN 1 ELSE 0 END) OVER(PARTITION BY t_month) AS l,
+        SUM(CASE WHEN (additions + deletions) >= 500 AND (additions + deletions) < 1000 THEN 1 ELSE 0 END) OVER(PARTITION BY t_month) AS xl,
+        SUM(CASE WHEN (additions + deletions) >= 1000 THEN 1 ELSE 0 END) OVER (PARTITION BY t_month) AS xxl,
+        COUNT(*) OVER (PARTITION BY t_month) AS all_size,
+        ROW_NUMBER() OVER (PARTITION BY t_month) AS row_num
     FROM (
         SELECT
-            DATE_FORMAT(created_at, '%Y-%m-01') as event_month,
+            DATE_FORMAT(created_at, '%Y-%m-01') as t_month,
             additions,
             deletions
         FROM
@@ -24,5 +24,5 @@ FROM (
     ) sub
 ) sub
 WHERE row_num = 1
-ORDER BY event_month
+ORDER BY t_month
 ;

--- a/configs/queries/analyze-recent-pull-requests/template.sql
+++ b/configs/queries/analyze-recent-pull-requests/template.sql
@@ -58,7 +58,6 @@ WITH RECURSIVE seq(idx, current_period_day, last_period_day) AS (
                 AND action = 'closed'
                 AND pr_merged = true
                 AND repo_id = 41986369
-                AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
                 AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
             GROUP BY day
             ORDER BY day

--- a/configs/queries/analyze-recent-top-contributors/template.sql
+++ b/configs/queries/analyze-recent-top-contributors/template.sql
@@ -7,7 +7,7 @@ WITH prs AS (
         repo_id = 41986369
         AND type = 'PullRequestEvent'
         AND action = 'opened'
-        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY)
         AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
     GROUP BY actor_login
 ), issues AS (
@@ -19,7 +19,7 @@ WITH prs AS (
         repo_id = 41986369
         AND type = 'IssuesEvent'
         AND action = 'opened'
-        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY)
         AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
     GROUP BY actor_login
 ), reviews AS (
@@ -31,7 +31,7 @@ WITH prs AS (
         repo_id = 41986369
         AND type = 'PullRequestReviewEvent'
         AND action = 'created'
-        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY)
         AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
     GROUP BY actor_login
 ), pushes AS (
@@ -43,11 +43,11 @@ WITH prs AS (
         repo_id = 41986369
         AND type = 'PushEvent'
         AND action = ''
-        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY)
         AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
     GROUP BY actor_login
 )
-SELECT actor_login, events
+SELECT actor_login, SUM(sub.events) AS events
 FROM (
     SELECT * FROM prs
     UNION
@@ -56,7 +56,7 @@ FROM (
     SELECT * FROM reviews
     UNION
     SELECT * FROM pushes
-)
+) sub
 GROUP BY actor_login
-ORDER BY events DESC
+ORDER BY SUM(sub.events) DESC
 LIMIT 5

--- a/configs/queries/analyze-stars-history/params.json
+++ b/configs/queries/analyze-stars-history/params.json
@@ -6,6 +6,7 @@
     {
       "name": "repoId",
       "replaces": "41986369",
+      "type": "array",
       "pattern": "^[1-9]\\d*$"
     }
   ],
@@ -25,6 +26,6 @@
         "description": "Total stars in the month"
       }
     },
-    "required": ["event_month", "total"]
+    "required": ["event_month", "repo_id", "total"]
   }
 }

--- a/configs/queries/analyze-stars-history/params.json
+++ b/configs/queries/analyze-stars-history/params.json
@@ -6,7 +6,6 @@
     {
       "name": "repoId",
       "replaces": "41986369",
-      "type": "array",
       "pattern": "^[1-9]\\d*$"
     }
   ],
@@ -26,6 +25,6 @@
         "description": "Total stars in the month"
       }
     },
-    "required": ["event_month", "repo_id", "total"]
+    "required": ["event_month", "total"]
   }
 }

--- a/configs/queries/analyze-stars-history/template.sql
+++ b/configs/queries/analyze-stars-history/template.sql
@@ -1,20 +1,36 @@
-SELECT
-    t_month AS event_month,
-    repo_id,
-    total
-FROM (
+WITH stars AS (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
         repo_id,
-        COUNT(actor_login) OVER(ORDER BY repo_id, DATE_FORMAT(created_at, '%Y-%m-01')) AS total,
-        ROW_NUMBER() OVER(PARTITION BY repo_id, DATE_FORMAT(created_at, '%Y-%m-01')) AS row_num
+        created_at,
+        ROW_NUMBER() OVER (PARTITION BY repo_id, actor_login) AS row_num
     FROM github_events
     WHERE
         type = 'WatchEvent'
-        AND repo_id = (41986369)
-    ORDER BY t_month
-) acc
-WHERE
-    row_num = 1
+        AND repo_id IN (41986369)
+), stars_per_month AS (
+    SELECT
+        repo_id,
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
+        COUNT(*) AS total
+    FROM stars
+    WHERE
+        row_num = 1
+    GROUP BY
+        repo_id, t_month
+), acc AS (
+    SELECT
+        repo_id,
+        t_month,
+        SUM(total) OVER (PARTITION BY repo_id ORDER BY t_month) AS total,
+        ROW_NUMBER() OVER(PARTITION BY repo_id, t_month) AS row_num
+    FROM
+        stars_per_month
+)
+SELECT
+    repo_id,
+    t_month AS event_month,
+    total
+FROM acc
+WHERE row_num = 1
 ORDER BY t_month
 ;

--- a/configs/queries/analyze-stars-history/template.sql
+++ b/configs/queries/analyze-stars-history/template.sql
@@ -1,17 +1,17 @@
 SELECT
-    event_month, repo_id, total
+    t_month AS event_month, total
 FROM (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') as event_month,
-        repo_id,
-        COUNT(actor_login) OVER(ORDER BY DATE_FORMAT(created_at, '%Y-%m-01') ASC) AS total,
-        ROW_NUMBER() OVER(PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01')) AS row_num
+        DATE_FORMAT(created_at, '%Y-%m-01')                                   as t_month,
+        COUNT(actor_login) OVER(ORDER BY DATE_FORMAT(created_at, '%Y-%m-01')) AS total,
+        ROW_NUMBER() OVER(PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01'))   AS row_num
     FROM github_events
     WHERE
-        type = 'WatchEvent' AND repo_id = 41986369
-    ORDER BY event_month
+        type = 'WatchEvent'
+        AND repo_id = 41986369
+    ORDER BY t_month
 ) acc
 WHERE
     row_num = 1
-ORDER BY event_month
+ORDER BY t_month
 ;

--- a/configs/queries/analyze-stars-history/template.sql
+++ b/configs/queries/analyze-stars-history/template.sql
@@ -1,14 +1,17 @@
 SELECT
-    t_month AS event_month, total
+    t_month AS event_month,
+    repo_id,
+    total
 FROM (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01')                                   as t_month,
-        COUNT(actor_login) OVER(ORDER BY DATE_FORMAT(created_at, '%Y-%m-01')) AS total,
-        ROW_NUMBER() OVER(PARTITION BY DATE_FORMAT(created_at, '%Y-%m-01'))   AS row_num
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
+        repo_id,
+        COUNT(actor_login) OVER(ORDER BY repo_id, DATE_FORMAT(created_at, '%Y-%m-01')) AS total,
+        ROW_NUMBER() OVER(PARTITION BY repo_id, DATE_FORMAT(created_at, '%Y-%m-01')) AS row_num
     FROM github_events
     WHERE
         type = 'WatchEvent'
-        AND repo_id = 41986369
+        AND repo_id = (41986369)
     ORDER BY t_month
 ) acc
 WHERE

--- a/configs/queries/analyze-stars-map/params.json
+++ b/configs/queries/analyze-stars-map/params.json
@@ -8,14 +8,14 @@
     },
     {
       "name": "period",
-      "replaces": "AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))",
+      "replaces": "AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY)",
       "enums": [
         "last_28_days",
         "all_times"
       ],
       "default": "all_times",
       "template": {
-        "last_28_days": "AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))",
+        "last_28_days": "AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY)",
         "all_times": ""
       }
     }

--- a/configs/queries/analyze-stars-map/template.sql
+++ b/configs/queries/analyze-stars-map/template.sql
@@ -8,11 +8,8 @@ WITH group_by_area AS (
         repo_id IN (41986369)
         AND ge.type = 'WatchEvent'
         AND ge.action = 'started'
-        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY) AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
-        AND gu.country_code IS NOT NULL  -- TODO: remove
-        AND gu.country_code != ''
-        AND gu.country_code != 'N/A'
-        AND gu.country_code != 'UND'
+        AND ge.created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY)
+        AND gu.country_code NOT IN ('', 'N/A', 'UND')
     GROUP BY country_or_area
 ), summary AS (
     SELECT SUM(cnt) AS total FROM group_by_area

--- a/configs/queries/collection-issues-history-rank/params.json
+++ b/configs/queries/collection-issues-history-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-issues-history-rank/template.sql
+++ b/configs/queries/collection-issues-history-rank/template.sql
@@ -1,32 +1,32 @@
-WITH acc AS (
+WITH accumulative_issues_by_year AS (
     SELECT
-        YEAR(created_at) AS t_year,
+        t_year,
         repo_id,
-        COUNT(*) OVER(PARTITION BY repo_id ORDER BY YEAR(created_at)) AS total,
-        ROW_NUMBER() OVER(PARTITION BY repo_id, YEAR(created_at) ORDER BY created_at) AS row_num
-    FROM github_events ge
+        COUNT(*) OVER (PARTITION BY repo_id ORDER BY t_year) AS total,
+        -- De-duplicate by `t_year` column, keeping only the first accumulative value of each year.
+        ROW_NUMBER() OVER (PARTITION BY repo_id, t_year)     AS row_num_by_year
+    FROM (
+        SELECT
+            repo_id,
+            YEAR(created_at) AS t_year,
+            -- De-duplicate by `number` column, keeping only the first event of each issue.
+            ROW_NUMBER() OVER (PARTITION BY repo_id, number ORDER BY created_at) AS row_num_by_number
+        FROM github_events ge
+        WHERE
+            type = 'IssuesEvent'
+            AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
+    ) sub
     WHERE
-        type = 'IssuesEvent'
-        AND action = 'opened'
-        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
-        -- Exclude Bots
-        AND actor_login NOT LIKE '%bot%'
-        AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
-), acc_group_by_year AS (
-    SELECT repo_id, t_year, total
-    FROM acc
-    WHERE row_num = 1
-    GROUP BY repo_id, t_year
-    ORDER BY t_year
+        row_num_by_number = 1
 )
 SELECT
-    t_year AS event_year,
-    gr.repo_id AS repo_id,
-    gr.repo_name AS repo_name,
-    total,
-    ROW_NUMBER() OVER (PARTITION BY t_year ORDER BY total DESC) AS `rank`
-FROM acc_group_by_year acc
-LEFT JOIN github_repos gr ON acc.repo_id = gr.repo_id
-WHERE acc.repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
-ORDER BY t_year, total DESC
+    ROW_NUMBER() OVER (PARTITION BY t_year ORDER BY total DESC) AS `rank`,
+    ci.repo_id AS repo_id,
+    ci.repo_name AS repo_name,
+    acc.t_year AS event_year,
+    acc.total
+FROM accumulative_issues_by_year acc
+JOIN collection_items ci ON collection_id = 10001 AND ci.repo_id = acc.repo_id
+WHERE row_num_by_year = 1
+ORDER BY t_year
 ;

--- a/configs/queries/collection-issues-history-rank/template.sql
+++ b/configs/queries/collection-issues-history-rank/template.sql
@@ -1,36 +1,32 @@
 WITH acc AS (
     SELECT
-        event_year,
-        repo_name,
-        COUNT(number) OVER(PARTITION BY repo_name ORDER BY event_year ASC) AS total
-    FROM (
-        SELECT
-            event_year,
-            number,
-            FIRST_VALUE(repo_name) OVER (PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-            ROW_NUMBER() OVER(PARTITION BY number) AS row_num
-        FROM github_events
-        WHERE
-            type = 'PullRequestEvent'
-            AND state = 'open'
-            AND repo_id IN (41986369, 16563587, 105944401)
-            -- Exclude Bots
-            AND actor_login NOT LIKE '%bot%'
-            AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
-    ) pr_with_latest_repo_name
-    WHERE row_num = 1
-    ORDER BY 1
-), acc_dist AS (
-    SELECT event_year, repo_name, ANY_VALUE(total) AS total
+        YEAR(created_at) AS t_year,
+        repo_id,
+        COUNT(*) OVER(PARTITION BY repo_id ORDER BY YEAR(created_at)) AS total,
+        ROW_NUMBER() OVER(PARTITION BY repo_id, YEAR(created_at) ORDER BY created_at) AS row_num
+    FROM github_events ge
+    WHERE
+        type = 'IssuesEvent'
+        AND action = 'opened'
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
+        -- Exclude Bots
+        AND actor_login NOT LIKE '%bot%'
+        AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+), acc_group_by_year AS (
+    SELECT repo_id, t_year, total
     FROM acc
-    GROUP BY 1, 2
-    ORDER BY 1
+    WHERE row_num = 1
+    GROUP BY repo_id, t_year
+    ORDER BY t_year
 )
 SELECT
-    event_year,
-    repo_name,
+    t_year AS event_year,
+    gr.repo_id AS repo_id,
+    gr.repo_name AS repo_name,
     total,
-    ROW_NUMBER() OVER (PARTITION BY event_year ORDER BY total DESC) AS `rank`
-FROM acc_dist
-ORDER BY event_year, total DESC
+    ROW_NUMBER() OVER (PARTITION BY t_year ORDER BY total DESC) AS `rank`
+FROM acc_group_by_year acc
+LEFT JOIN github_repos gr ON acc.repo_id = gr.repo_id
+WHERE acc.repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
+ORDER BY t_year, total DESC
 ;

--- a/configs/queries/collection-issues-history/params.json
+++ b/configs/queries/collection-issues-history/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "replaces": "41986369, 16563587, 105944401",
-      "enums": "collectionIds",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-issues-history/template.sql
+++ b/configs/queries/collection-issues-history/template.sql
@@ -1,26 +1,33 @@
 WITH acc AS (
     SELECT
-        event_month,
-        repo_name,
-        COUNT(number) OVER(PARTITION BY repo_name ORDER BY event_month ASC) AS total
-    FROM (
-        SELECT
-            event_month,
-            number,
-            FIRST_VALUE(repo_name) OVER (PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-            ROW_NUMBER() OVER(PARTITION BY number) AS row_num
-        FROM github_events
-        WHERE
-            type = 'IssuesEvent' AND repo_id IN (41986369, 16563587, 105944401)
-            -- Exclude Bots
-            AND actor_login NOT LIKE '%bot%'
-            AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
-    ) issues_with_latest_repo_name
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
+        repo_id,
+        COUNT(*) OVER (PARTITION BY repo_id ORDER BY DATE_FORMAT(created_at, '%Y-%m-01')) AS total,
+        ROW_NUMBER() OVER (PARTITION BY repo_id, DATE_FORMAT(created_at, '%Y-%m-01')) AS row_num
+    FROM github_events ge
+    USE INDEX(index_ge_on_repo_id_type_action_created_at_actor_login)
+    WHERE
+        type = 'IssuesEvent'
+        AND action = 'opened'
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
+        -- Exclude Bots
+        AND actor_login NOT LIKE '%bot%'
+        AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+), acc_group_by_month AS (
+    SELECT
+        t_month,
+        repo_id,
+        total
+    FROM acc
     WHERE row_num = 1
-    ORDER BY 1
 )
-SELECT event_month, repo_name, ANY_VALUE(total) AS total
-FROM acc
-GROUP BY 1, 2
-ORDER BY 1
+SELECT
+    acc.t_month AS event_month,
+    gr.repo_name AS repo_name,
+    acc.total
+FROM acc_group_by_month acc
+LEFT JOIN github_repos gr ON gr.repo_id = acc.repo_id
+WHERE
+    gr.repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
+ORDER BY t_month
 ;

--- a/configs/queries/collection-issues-last-28-days-rank/params.json
+++ b/configs/queries/collection-issues-last-28-days-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-issues-last-28-days-rank/template.sql
+++ b/configs/queries/collection-issues-last-28-days-rank/template.sql
@@ -3,9 +3,11 @@ WITH issues_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS issues
     FROM github_events
+    -- TODO: remove
+    USE INDEX(index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'IssuesEvent'
-        AND repo_id IN (41986369, 16563587, 105944401)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
         AND action = 'opened'
     GROUP BY repo_id
 ), issues_group_by_period AS (
@@ -18,8 +20,7 @@ WITH issues_group_by_repo AS (
     WHERE
         type = 'IssuesEvent'
         AND action = 'opened'
-        AND repo_id IN (41986369, 16563587, 105944401)
-        AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
         AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
     GROUP BY period, repo_id
 ), issues_last_period AS (

--- a/configs/queries/collection-issues-last-28-days-rank/template.sql
+++ b/configs/queries/collection-issues-last-28-days-rank/template.sql
@@ -3,30 +3,25 @@ WITH issues_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS issues
     FROM github_events
-    -- TODO: remove
-    USE INDEX(index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'IssuesEvent'
-        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
-        AND action = 'opened'
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
     GROUP BY repo_id
 ), issues_group_by_period AS (
     SELECT
-        (DATEDIFF(CURRENT_DATE(), event_day)) DIV 28 AS period,
+        (DATEDIFF(CURRENT_DATE(), DATE(created_at))) DIV 28 AS period,
         repo_id,
-        ANY_VALUE(repo_name) AS repo_name,
         COUNT(DISTINCT number) AS issues
     FROM github_events
     WHERE
         type = 'IssuesEvent'
         AND action = 'opened'
-        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
         AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
     GROUP BY period, repo_id
 ), issues_last_period AS (
     SELECT
         repo_id,
-        repo_name,
         issues,
         ROW_NUMBER() OVER(ORDER BY issues DESC) AS `rank`
     FROM
@@ -37,7 +32,6 @@ WITH issues_group_by_repo AS (
 ), issues_last_2nd_period AS (
     SELECT
         repo_id,
-        repo_name,
         issues,
         ROW_NUMBER() OVER(ORDER BY issues DESC) AS `rank`
     FROM
@@ -46,17 +40,21 @@ WITH issues_group_by_repo AS (
         period = 1
 )
 SELECT
-    ilp.repo_id,
-    ilp.repo_name,
+    ci.repo_id,
+    ci.repo_name,
     -- Issues
     IFNULL(ilp.issues, 0) AS last_period_total,
     IFNULL(ilp.`rank`, 0) AS last_period_rank,
     IFNULL(il2p.issues, 0) AS last_2nd_period_total,
     IFNULL(il2p.`rank`, 0) AS last_2nd_period_rank,
+    -- The changes of total issues between two periods.
     IFNULL(((ilp.issues - il2p.issues) / il2p.issues) * 100, 0) AS total_pop,
+    -- The rank changes between two periods.
     IFNULL((ilp.`rank` - il2p.`rank`), 0) AS rank_pop,
+    -- The total issues of repo.
     IFNULL(igr.issues, 0) AS total
 FROM issues_group_by_repo igr
+JOIN collection_items ci ON ci.collection_id = 10001 AND igr.repo_id = ci.repo_id
 JOIN issues_last_period ilp ON igr.repo_id = ilp.repo_id
 LEFT JOIN issues_last_2nd_period il2p ON igr.repo_id = il2p.repo_id
 ORDER BY last_period_rank;

--- a/configs/queries/collection-issues-last-28-days-rank/template.sql
+++ b/configs/queries/collection-issues-last-28-days-rank/template.sql
@@ -3,6 +3,7 @@ WITH issues_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS issues
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'IssuesEvent'
         AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
@@ -13,6 +14,7 @@ WITH issues_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS issues
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'IssuesEvent'
         AND action = 'opened'

--- a/configs/queries/collection-issues-month-rank/params.json
+++ b/configs/queries/collection-issues-month-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-issues-month-rank/template.sql
+++ b/configs/queries/collection-issues-month-rank/template.sql
@@ -3,50 +3,52 @@ WITH issues_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS issues
     FROM github_events
+    -- TODO: remove
+    USE INDEX(index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'IssuesEvent'
-        AND repo_id IN (41986369, 16563587, 105944401)
         AND action = 'opened'
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
     GROUP BY repo_id
 ), issues_group_by_month AS (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') AS event_month,
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
         repo_id,
         COUNT(DISTINCT number) AS issues
     FROM github_events
     WHERE
         type = 'IssuesEvent'
         AND action = 'opened'
-        AND repo_id IN (41986369, 16563587, 105944401)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
         AND created_at < DATE_FORMAT(NOW(), '%Y-%m-01')
         AND created_at >= DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
-    GROUP BY DATE_FORMAT(created_at, '%Y-%m-01'), repo_id
+    GROUP BY t_month, repo_id
 ), issues_last_month AS (
     SELECT
-        event_month,
+        t_month,
         repo_id,
         issues,
         ROW_NUMBER() OVER(ORDER BY issues DESC) AS `rank`
     FROM
         issues_group_by_month sgn
     WHERE
-        event_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01')
+        t_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01')
 ), issues_last_2nd_month AS (
     SELECT
-        event_month,
+        t_month,
         repo_id,
         issues,
         ROW_NUMBER() OVER(ORDER BY issues DESC) AS `rank`
     FROM
         issues_group_by_month sgn
     WHERE
-        event_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
+        t_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
 )
 SELECT
     ilm.repo_id,
     r.repo_name,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL DAYOFMONTH(NOW()) DAY), '%Y-%m') AS current_month,
-    DATE_FORMAT(DATE_SUB(DATE_SUB(NOW(), INTERVAL DAYOFMONTH(NOW()) DAY), INTERVAL 1 MONTH), '%Y-%m') AS last_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01') AS current_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01') AS last_month,
     -- Issues
     ilm.issues AS current_month_total,
     ilm.`rank` AS current_month_rank,

--- a/configs/queries/collection-issues-month-rank/template.sql
+++ b/configs/queries/collection-issues-month-rank/template.sql
@@ -3,6 +3,7 @@ WITH issues_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS issues
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'IssuesEvent'
         AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)

--- a/configs/queries/collection-issues-month-rank/template.sql
+++ b/configs/queries/collection-issues-month-rank/template.sql
@@ -44,8 +44,8 @@ WITH issues_group_by_repo AS (
 SELECT
     ci.repo_id,
     ci.repo_name,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01') AS current_month,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01') AS last_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m') AS current_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m') AS last_month,
     -- Issues
     ilm.issues AS current_month_total,
     ilm.`rank` AS current_month_rank,

--- a/configs/queries/collection-issues-month-rank/template.sql
+++ b/configs/queries/collection-issues-month-rank/template.sql
@@ -3,12 +3,9 @@ WITH issues_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS issues
     FROM github_events
-    -- TODO: remove
-    USE INDEX(index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'IssuesEvent'
-        AND action = 'opened'
-        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
     GROUP BY repo_id
 ), issues_group_by_month AS (
     SELECT
@@ -19,7 +16,7 @@ WITH issues_group_by_repo AS (
     WHERE
         type = 'IssuesEvent'
         AND action = 'opened'
-        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 200)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
         AND created_at < DATE_FORMAT(NOW(), '%Y-%m-01')
         AND created_at >= DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
     GROUP BY t_month, repo_id
@@ -45,8 +42,8 @@ WITH issues_group_by_repo AS (
         t_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
 )
 SELECT
-    ilm.repo_id,
-    r.repo_name,
+    ci.repo_id,
+    ci.repo_name,
     DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01') AS current_month,
     DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01') AS last_month,
     -- Issues
@@ -54,11 +51,14 @@ SELECT
     ilm.`rank` AS current_month_rank,
     IFNULL(il2m.issues, 0) AS last_month_total,
     il2m.`rank` AS last_month_rank,
+    -- The total changes period over period.
     ((ilm.issues - il2m.issues) / il2m.issues) * 100 AS total_mom,
+    -- The rank changes period over period.
     (ilm.`rank` - il2m.`rank`) AS rank_mom,
+    -- The total issues of repo.
     igr.issues AS total
 FROM issues_group_by_repo igr
+JOIN collection_items ci ON ci.collection_id = 10001 AND igr.repo_id = ci.repo_id
 JOIN issues_last_month ilm ON igr.repo_id = ilm.repo_id
 LEFT JOIN issues_last_2nd_month il2m ON ilm.repo_id = il2m.repo_id
-LEFT JOIN github_repos r ON igr.repo_id = r.repo_id
 ORDER BY current_month_rank;

--- a/configs/queries/collection-pull-request-creators-history-rank/params.json
+++ b/configs/queries/collection-pull-request-creators-history-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-pull-request-creators-history-rank/template.sql
+++ b/configs/queries/collection-pull-request-creators-history-rank/template.sql
@@ -9,7 +9,7 @@ WITH accumulative_prs_by_year AS (
         SELECT
             repo_id,
             YEAR(created_at) AS t_year,
-            -- De-duplicate by `actor_login` column, keeping only the first event of each PR.
+            -- De-duplicate by `actor_login` column, keeping only the first PR of each PR creator.
             ROW_NUMBER() OVER (PARTITION BY repo_id, actor_login ORDER BY created_at) AS row_num_by_actor_login
         FROM github_events ge
         WHERE

--- a/configs/queries/collection-pull-request-creators-history-rank/template.sql
+++ b/configs/queries/collection-pull-request-creators-history-rank/template.sql
@@ -1,52 +1,34 @@
-WITH pr_opened AS (
+WITH accumulative_prs_by_year AS (
     SELECT
-        event_year,
-        actor_login,
+        t_year,
         repo_id,
-        repo_name,
-        number,
-        created_at
-    FROM github_events
+        COUNT(*) OVER (PARTITION BY repo_id ORDER BY t_year) AS total,
+        -- De-duplicate by `t_month` column, keeping only the first accumulative value of each year.
+        ROW_NUMBER() OVER (PARTITION BY repo_id, t_year) AS row_num_by_year
+    FROM (
+        SELECT
+            repo_id,
+            YEAR(created_at) AS t_year,
+            -- De-duplicate by `actor_login` column, keeping only the first event of each PR.
+            ROW_NUMBER() OVER (PARTITION BY repo_id, actor_login ORDER BY created_at) AS row_num_by_actor_login
+        FROM github_events ge
+        WHERE
+            type = 'PullRequestEvent'
+            AND action = 'opened'
+            AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
+    ) sub
     WHERE
-        type = 'PullRequestEvent'
-        AND state = 'open'
-        AND repo_id IN (41986369, 16563587, 105944401)
-), pr_merged AS (
-    SELECT
-        number
-    FROM github_events
-    WHERE
-        type = 'PullRequestEvent'
-        AND state = 'closed'
-        AND pr_merged = true
-        AND repo_id IN (41986369, 16563587, 105944401)
-), pr_creators_with_latest_repo_name AS (
-    SELECT
-        event_year,
-        actor_login,
-        FIRST_VALUE(repo_name) OVER (PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-        ROW_NUMBER() OVER(PARTITION BY actor_login) AS row_num
-    FROM pr_opened po
-    JOIN pr_merged pm ON po.number = pm.number
-), acc AS (
-    SELECT
-        event_year,
-        repo_name,
-        COUNT(actor_login) OVER(PARTITION BY repo_name ORDER BY event_year ASC) AS total
-    FROM pr_creators_with_latest_repo_name
-    WHERE row_num = 1
-    ORDER BY 1
-), acc_dist AS (
-    SELECT event_year, repo_name, ANY_VALUE(total) AS total
-    FROM acc
-    GROUP BY 1, 2
-    ORDER BY 1
+        row_num_by_actor_login = 1
 )
 SELECT
-    event_year,
-    repo_name,
-    total,
-    ROW_NUMBER() OVER (PARTITION BY event_year ORDER BY total DESC) AS `rank`
-FROM acc_dist
-ORDER BY event_year, total DESC
+    ROW_NUMBER() OVER (PARTITION BY t_year ORDER BY total DESC) AS `rank`,
+    ci.repo_id AS repo_id,
+    ci.repo_name AS repo_name,
+    acc.t_year AS event_year,
+    -- The accumulative PR creators of repo.
+    acc.total
+FROM accumulative_prs_by_year acc
+JOIN collection_items ci ON collection_id = 10001 AND ci.repo_id = acc.repo_id
+WHERE row_num_by_year = 1
+ORDER BY t_year
 ;

--- a/configs/queries/collection-pull-request-creators-history/params.json
+++ b/configs/queries/collection-pull-request-creators-history/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-pull-request-creators-history/template.sql
+++ b/configs/queries/collection-pull-request-creators-history/template.sql
@@ -1,44 +1,28 @@
-WITH pr_opened AS (
+WITH prs_opened AS (
     SELECT
-        event_month,
-        actor_login,
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
         repo_id,
-        repo_name,
-        number,
-        created_at
-    FROM github_events
+        COUNT(DISTINCT actor_login) AS pr_creators
+    FROM github_events ge
     WHERE
         type = 'PullRequestEvent'
         AND action = 'opened'
-        AND repo_id IN (41986369, 16563587, 105944401)
-), pr_merged AS (
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 500)
+    GROUP BY repo_id, t_month
+), prs_opened_group_by_month AS (
     SELECT
-        number
-    FROM github_events
-    WHERE
-        type = 'PullRequestEvent'
-        AND action = 'closed'
-        AND pr_merged = true
-        AND repo_id IN (41986369, 16563587, 105944401)
-), pr_creators_with_latest_repo_name AS (
-    SELECT
-        event_month,
-        actor_login,
-        FIRST_VALUE(repo_name) OVER (PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-        ROW_NUMBER() OVER(PARTITION BY repo_id, actor_login) AS row_num
-    FROM pr_opened po
-    JOIN pr_merged pm ON po.number = pm.number
-), acc AS (
-    SELECT
-        event_month,
-        repo_name,
-        COUNT(actor_login) OVER(PARTITION BY repo_name ORDER BY event_month ASC) AS total
-    FROM pr_creators_with_latest_repo_name
-    WHERE row_num = 1
-    ORDER BY 1
+        t_month,
+        repo_id,
+        SUM(pr_creators) OVER (PARTITION BY repo_id ORDER BY t_month) AS prs
+    FROM prs_opened
 )
-SELECT event_month, repo_name, ANY_VALUE(total) AS total
-FROM acc
-GROUP BY 1, 2
-ORDER BY 1
+SELECT
+     pogbm.t_month AS event_month,
+     gr.repo_id,
+     gr.repo_name,
+     pogbm.prs AS total
+FROM prs_opened_group_by_month pogbm
+         JOIN github_repos gr ON pogbm.repo_id = gr.repo_id
+GROUP BY t_month, repo_id
+ORDER BY t_month
 ;

--- a/configs/queries/collection-pull-request-creators-history/template.sql
+++ b/configs/queries/collection-pull-request-creators-history/template.sql
@@ -1,28 +1,33 @@
-WITH prs_opened AS (
-    SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
-        repo_id,
-        COUNT(DISTINCT actor_login) AS pr_creators
-    FROM github_events ge
-    WHERE
-        type = 'PullRequestEvent'
-        AND action = 'opened'
-        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001 LIMIT 500)
-    GROUP BY repo_id, t_month
-), prs_opened_group_by_month AS (
+WITH accumulative_pr_creators_by_month AS (
     SELECT
         t_month,
         repo_id,
-        SUM(pr_creators) OVER (PARTITION BY repo_id ORDER BY t_month) AS prs
-    FROM prs_opened
+        COUNT(*) OVER (PARTITION BY repo_id ORDER BY t_month) AS total,
+        -- De-duplicate by `t_month` column, keeping only the first accumulative value of each month.
+        ROW_NUMBER() OVER (PARTITION BY repo_id, t_month) AS row_num_by_month
+    FROM (
+        SELECT
+            repo_id,
+            DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
+            -- De-duplicate by `number` column, keeping only the first event of each PR.
+            ROW_NUMBER() OVER (PARTITION BY repo_id, actor_login ORDER BY created_at) AS row_num_by_actor_login
+        FROM github_events ge
+        WHERE
+            type = 'PullRequestEvent'
+            AND action = 'opened'
+            AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
+    ) sub
+    WHERE
+        row_num_by_actor_login = 1
 )
 SELECT
-     pogbm.t_month AS event_month,
-     gr.repo_id,
-     gr.repo_name,
-     pogbm.prs AS total
-FROM prs_opened_group_by_month pogbm
-         JOIN github_repos gr ON pogbm.repo_id = gr.repo_id
-GROUP BY t_month, repo_id
+    ci.repo_id AS repo_id,
+    ci.repo_name AS repo_name,
+    acc.t_month AS event_month,
+    -- The accumulative PR creators of repo.
+    acc.total
+FROM accumulative_pr_creators_by_month acc
+JOIN collection_items ci ON collection_id = 10001 AND ci.repo_id = acc.repo_id
+WHERE row_num_by_month = 1
 ORDER BY t_month
 ;

--- a/configs/queries/collection-pull-request-creators-history/template.sql
+++ b/configs/queries/collection-pull-request-creators-history/template.sql
@@ -9,7 +9,7 @@ WITH accumulative_pr_creators_by_month AS (
         SELECT
             repo_id,
             DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
-            -- De-duplicate by `number` column, keeping only the first event of each PR.
+            -- De-duplicate by `actor_login` column, keeping only the first event of each PR.
             ROW_NUMBER() OVER (PARTITION BY repo_id, actor_login ORDER BY created_at) AS row_num_by_actor_login
         FROM github_events ge
         WHERE

--- a/configs/queries/collection-pull-requests-history-rank/params.json
+++ b/configs/queries/collection-pull-requests-history-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-pull-requests-history/params.json
+++ b/configs/queries/collection-pull-requests-history/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-pull-requests-history/template.sql
+++ b/configs/queries/collection-pull-requests-history/template.sql
@@ -1,26 +1,32 @@
-WITH acc AS (
+WITH accumulative_prs_by_month AS (
     SELECT
-        event_month,
-        repo_name,
-        COUNT(number) OVER(PARTITION BY repo_name ORDER BY event_month ASC) AS total
+        t_month,
+        repo_id,
+        COUNT(*) OVER (PARTITION BY repo_id ORDER BY t_month) AS total,
+        -- De-duplicate by t_month column, keeping only the first accumulative value of each month.
+        ROW_NUMBER() OVER (PARTITION BY repo_id, t_month) AS row_num_by_month
     FROM (
         SELECT
-            event_month,
+            repo_id,
             number,
-            FIRST_VALUE(repo_name) OVER (PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-            ROW_NUMBER() OVER(PARTITION BY number) AS row_num
-        FROM github_events
+            DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
+            -- De-duplicate by number column, keeping only the first event of each PR.
+            ROW_NUMBER() OVER (PARTITION BY repo_id, number ORDER BY created_at) AS row_num_by_number
+        FROM github_events ge
         WHERE
-            type = 'PullRequestEvent' AND repo_id IN (41986369, 16563587, 105944401)
-            -- Exclude Bots
-            AND actor_login NOT LIKE '%bot%'
-            AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
-    ) prs_with_latest_repo_name
-    WHERE row_num = 1
-    ORDER BY 1
+            type = 'PullRequestEvent'
+            AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
+    ) sub
+    WHERE
+        row_num_by_number = 1
 )
-SELECT event_month, repo_name, ANY_VALUE(total) AS total
-FROM acc
-GROUP BY 1, 2
-ORDER BY 1
+SELECT
+    gr.repo_id AS repo_id,
+    gr.repo_name AS repo_name,
+    acc.t_month AS event_month,
+    acc.total
+FROM accumulative_prs_by_month acc
+LEFT JOIN github_repos gr ON gr.repo_id = acc.repo_id
+WHERE row_num_by_month = 1
+ORDER BY t_month
 ;

--- a/configs/queries/collection-pull-requests-last-28-days-rank/params.json
+++ b/configs/queries/collection-pull-requests-last-28-days-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-pull-requests-last-28-days-rank/template.sql
+++ b/configs/queries/collection-pull-requests-last-28-days-rank/template.sql
@@ -5,26 +5,23 @@ WITH prs_group_by_repo AS (
     FROM github_events
     WHERE
         type = 'PullRequestEvent'
-        AND repo_id IN (41986369, 16563587, 105944401)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
     GROUP BY repo_id
 ), prs_group_by_period AS (
     SELECT
-        (DATEDIFF(CURRENT_DATE(), event_day)) DIV 28 AS period,
+        (DATEDIFF(CURRENT_DATE(), DATE(created_at))) DIV 28 AS period,
         repo_id,
-        ANY_VALUE(repo_name) AS repo_name,
         COUNT(DISTINCT number) AS prs
     FROM github_events
     WHERE
         type = 'PullRequestEvent'
         AND action = 'opened'
-        AND repo_id IN (41986369, 16563587, 105944401)
-        AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
         AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
     GROUP BY period, repo_id
 ), prs_last_period AS (
     SELECT
         repo_id,
-        repo_name,
         prs,
         ROW_NUMBER() OVER(ORDER BY prs DESC) AS `rank`
     FROM
@@ -35,7 +32,6 @@ WITH prs_group_by_repo AS (
 ), prs_last_2nd_period AS (
     SELECT
         repo_id,
-        repo_name,
         prs,
         ROW_NUMBER() OVER(ORDER BY prs DESC) AS `rank`
     FROM
@@ -44,17 +40,21 @@ WITH prs_group_by_repo AS (
         period = 1
 )
 SELECT
-    plp.repo_id,
-    plp.repo_name,
+    ci.repo_id,
+    ci.repo_name,
     -- Pull Requests
     IFNULL(plp.prs, 0) AS last_period_total,
     IFNULL(plp.`rank`, 0) AS last_period_rank,
     IFNULL(pl2p.prs, 0) AS last_2nd_period_total,
     IFNULL(pl2p.`rank`, 0) AS last_2nd_period_rank,
+    -- The changes of total pull requests between two periods.
     IFNULL(((plp.prs - pl2p.prs) / pl2p.prs) * 100, 0) AS total_pop,
+    -- The rank changes between two periods.
     IFNULL((plp.`rank` - pl2p.`rank`), 0) AS rank_pop,
+    -- The total pull requests of repo.
     IFNULL(pgr.prs, 0) AS total
 FROM prs_group_by_repo pgr
+JOIN collection_items ci ON ci.collection_id = 10001 AND pgr.repo_id = ci.repo_id
 JOIN prs_last_period plp ON pgr.repo_id = plp.repo_id
 LEFT JOIN prs_last_2nd_period pl2p ON pgr.repo_id = pl2p.repo_id
 ORDER BY last_period_rank;

--- a/configs/queries/collection-pull-requests-last-28-days-rank/template.sql
+++ b/configs/queries/collection-pull-requests-last-28-days-rank/template.sql
@@ -3,6 +3,7 @@ WITH prs_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS prs
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'PullRequestEvent'
         AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)

--- a/configs/queries/collection-pull-requests-month-rank/params.json
+++ b/configs/queries/collection-pull-requests-month-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-pull-requests-month-rank/template.sql
+++ b/configs/queries/collection-pull-requests-month-rank/template.sql
@@ -5,55 +5,60 @@ WITH prs_group_by_repo AS (
     FROM github_events
     WHERE
         type = 'PullRequestEvent'
-        AND repo_id IN (41986369, 16563587, 105944401)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
     GROUP BY repo_id
 ), prs_group_by_month AS (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') AS event_month,
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
         repo_id,
-        COUNT(*) AS prs
+        COUNT(DISTINCT number) AS prs
     FROM github_events
     WHERE
         type = 'PullRequestEvent'
         AND action = 'opened'
-        AND repo_id IN (41986369, 16563587, 105944401)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
         AND created_at < DATE_FORMAT(NOW(), '%Y-%m-01')
         AND created_at >= DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
-    GROUP BY DATE_FORMAT(created_at, '%Y-%m-01'), repo_id
+    GROUP BY t_month, repo_id
 ), prs_last_month AS (
     SELECT
-        event_month,
+        t_month,
         repo_id,
         prs,
         ROW_NUMBER() OVER(ORDER BY prs DESC) AS `rank`
-    FROM prs_group_by_month sgn
+    FROM
+        prs_group_by_month sgn
     WHERE
-        event_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01')
+        t_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01')
 ), prs_last_2nd_month AS (
     SELECT
-        event_month,
+        t_month,
         repo_id,
         prs,
         ROW_NUMBER() OVER(ORDER BY prs DESC) AS `rank`
-    FROM prs_group_by_month sgn
+    FROM
+        prs_group_by_month sgn
     WHERE
-        event_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
+        t_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
 )
 SELECT
-    plm.repo_id,
-    r.repo_name,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL DAYOFMONTH(NOW()) DAY), '%Y-%m') AS current_month,
-    DATE_FORMAT(DATE_SUB(DATE_SUB(NOW(), INTERVAL DAYOFMONTH(NOW()) DAY), INTERVAL 1 MONTH), '%Y-%m') AS last_month,
-    -- PRs
-    plm.prs AS current_month_total,
-    plm.`rank` AS current_month_rank,
-    IFNULL(pl2m.prs, 0) AS last_month_total,
-    pl2m.`rank` AS last_month_rank,
-    ((plm.prs - pl2m.prs) / pl2m.prs) * 100 AS total_mom,
-    (plm.`rank` - pl2m.`rank`) AS rank_mom,
-    pgr.prs AS total
-FROM prs_group_by_repo pgr
-JOIN prs_last_month plm ON pgr.repo_id = plm.repo_id
-LEFT JOIN prs_last_2nd_month pl2m ON plm.repo_id = pl2m.repo_id
-LEFT JOIN github_repos r ON pgr.repo_id = r.repo_id
+    ci.repo_id,
+    ci.repo_name,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01') AS current_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01') AS last_month,
+    -- Pull requests.
+    ilm.prs AS current_month_total,
+    ilm.`rank` AS current_month_rank,
+    IFNULL(il2m.prs, 0) AS last_month_total,
+    il2m.`rank` AS last_month_rank,
+    -- The changes of total prs between the last two periods.
+    ((ilm.prs - il2m.prs) / il2m.prs) * 100 AS total_mom,
+    -- The rank changes between the last two periods.
+    (ilm.`rank` - il2m.`rank`) AS rank_mom,
+    -- The total prs of repo.
+    igr.prs AS total
+FROM prs_group_by_repo igr
+JOIN collection_items ci ON ci.collection_id = 10001 AND igr.repo_id = ci.repo_id
+JOIN prs_last_month ilm ON igr.repo_id = ilm.repo_id
+LEFT JOIN prs_last_2nd_month il2m ON ilm.repo_id = il2m.repo_id
 ORDER BY current_month_rank;

--- a/configs/queries/collection-pull-requests-month-rank/template.sql
+++ b/configs/queries/collection-pull-requests-month-rank/template.sql
@@ -44,8 +44,8 @@ WITH prs_group_by_repo AS (
 SELECT
     ci.repo_id,
     ci.repo_name,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01') AS current_month,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01') AS last_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m') AS current_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m') AS last_month,
     -- Pull requests.
     ilm.prs AS current_month_total,
     ilm.`rank` AS current_month_rank,

--- a/configs/queries/collection-pull-requests-month-rank/template.sql
+++ b/configs/queries/collection-pull-requests-month-rank/template.sql
@@ -3,6 +3,7 @@ WITH prs_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT number) AS prs
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_number_pdsize_psize)
     WHERE
         type = 'PullRequestEvent'
         AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)

--- a/configs/queries/collection-stars-history-rank/params.json
+++ b/configs/queries/collection-stars-history-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-stars-history-rank/template.sql
+++ b/configs/queries/collection-stars-history-rank/template.sql
@@ -1,32 +1,32 @@
-WITH stars_with_latest_repo_name AS (
+WITH accumulative_stars_by_year AS (
     SELECT
-        event_year,
-        actor_login,
-        FIRST_VALUE(repo_name) OVER (PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-        ROW_NUMBER() OVER(PARTITION BY repo_id, actor_login) AS row_num
-    FROM github_events
+        t_year,
+        repo_id,
+        COUNT(*) OVER (PARTITION BY repo_id ORDER BY t_year) AS total,
+        -- De-duplicate by `t_year` column, keeping only the first accumulative value of each year.
+        ROW_NUMBER() OVER (PARTITION BY repo_id, t_year)     AS row_num_by_year
+    FROM (
+        SELECT
+            repo_id,
+            YEAR(created_at) AS t_year,
+            -- De-duplicate by `actor_login` column, keeping only the first event of each star.
+            ROW_NUMBER() OVER (PARTITION BY ge.repo_id, actor_login ORDER BY created_at) AS row_num_by_actor_login
+        FROM github_events ge
+        WHERE
+            type = 'WatchEvent'
+            AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
+    ) sub
     WHERE
-        type = 'WatchEvent'
-        AND repo_id IN (41986369, 16563587, 105944401)
-), acc AS (
-    SELECT
-        event_year,
-        repo_name,
-        COUNT(actor_login) OVER(PARTITION BY repo_name ORDER BY event_year ASC) AS total
-    FROM stars_with_latest_repo_name
-    WHERE row_num = 1
-    ORDER BY 1
-), acc_dist AS (
-    SELECT event_year, repo_name, ANY_VALUE(total) AS total
-    FROM acc
-    GROUP BY 1, 2
-    ORDER BY 1
+        row_num_by_actor_login = 1
 )
 SELECT
-    event_year,
-    repo_name,
-    total,
-    ROW_NUMBER() OVER (PARTITION BY event_year ORDER BY total DESC) AS `rank`
-FROM acc_dist
-ORDER BY event_year, total DESC
+    ROW_NUMBER() OVER (PARTITION BY t_year ORDER BY total DESC) AS `rank`,
+    ci.repo_id   AS repo_id,
+    ci.repo_name AS repo_name,
+    acc.t_year   AS event_year,
+    acc.total
+FROM accumulative_stars_by_year acc
+JOIN collection_items ci ON collection_id = 10001 AND ci.repo_id = acc.repo_id
+WHERE row_num_by_year = 1
+ORDER BY t_year
 ;

--- a/configs/queries/collection-stars-history/params.json
+++ b/configs/queries/collection-stars-history/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-stars-history/template.sql
+++ b/configs/queries/collection-stars-history/template.sql
@@ -9,7 +9,7 @@ WITH accumulative_stars_by_month AS (
         SELECT
             repo_id,
             DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
-            -- De-duplicate by number column, keeping only the first event of each issue.
+            -- De-duplicate by actor_login column, keeping only the first event of each star.
             ROW_NUMBER() OVER (PARTITION BY ge.repo_id, actor_login ORDER BY created_at) AS row_num_by_actor_login
         FROM github_events ge
         WHERE

--- a/configs/queries/collection-stars-history/template.sql
+++ b/configs/queries/collection-stars-history/template.sql
@@ -1,23 +1,31 @@
-WITH acc AS (
+WITH accumulative_stars_by_month AS (
     SELECT
-        event_month,
-        repo_name,
-        COUNT(actor_login) OVER(PARTITION BY repo_name ORDER BY event_month ASC) AS total
+        t_month,
+        repo_id,
+        COUNT(*) OVER (PARTITION BY repo_id ORDER BY t_month) AS total,
+        -- De-duplicate by t_month column, keeping only the first accumulative value of each month.
+        ROW_NUMBER() OVER (PARTITION BY repo_id, t_month) AS row_num_by_month
     FROM (
         SELECT
-            event_month,
-            actor_login,
-            FIRST_VALUE(repo_name) OVER (PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-            ROW_NUMBER() OVER(PARTITION BY repo_id, actor_login) AS row_num
-        FROM github_events
+            repo_id,
+            DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
+            -- De-duplicate by number column, keeping only the first event of each issue.
+            ROW_NUMBER() OVER (PARTITION BY ge.repo_id, actor_login ORDER BY created_at) AS row_num_by_actor_login
+        FROM github_events ge
         WHERE
-            type = 'WatchEvent' AND repo_id IN (41986369, 16563587, 105944401)
+            type = 'WatchEvent'
+            AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
     ) sub
-    WHERE row_num = 1
-    ORDER BY event_month
+    WHERE
+        row_num_by_actor_login = 1
 )
-SELECT event_month, repo_name, total
-FROM acc
-GROUP BY event_month, repo_name
-ORDER BY event_month
+SELECT
+    ci.repo_id AS repo_id,
+    ci.repo_name AS repo_name,
+    acc.t_month AS event_month,
+    acc.total
+FROM accumulative_stars_by_month acc
+JOIN collection_items ci ON collection_id = 10001 AND ci.repo_id = acc.repo_id
+WHERE row_num_by_month = 1
+ORDER BY t_month
 ;

--- a/configs/queries/collection-stars-last-28-days-rank/params.json
+++ b/configs/queries/collection-stars-last-28-days-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-stars-last-28-days-rank/template.sql
+++ b/configs/queries/collection-stars-last-28-days-rank/template.sql
@@ -1,30 +1,28 @@
 WITH stars_group_by_repo AS (
     SELECT
         repo_id,
-        COUNT(actor_login) AS stars
-    FROM github_events
-    WHERE
-        type = 'WatchEvent'
-        AND repo_id IN (41986369, 16563587, 105944401)
-    GROUP BY repo_id
-), stars_group_by_period AS (
-    SELECT
-        (DATEDIFF(CURRENT_DATE(), event_day)) DIV 28 AS period,
-        repo_id,
-        ANY_VALUE(repo_name) AS repo_name,
-        COUNT(actor_login) AS stars
+        COUNT(DISTINCT actor_login) AS prs
     FROM github_events
     WHERE
         type = 'WatchEvent'
         AND action = 'started'
-        AND repo_id IN (41986369, 16563587, 105944401)
-        AND (event_month BETWEEN DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY), '%Y-%m-01') AND DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'))
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
+    GROUP BY repo_id
+), stars_group_by_period AS (
+    SELECT
+        (DATEDIFF(CURRENT_DATE(), DATE(created_at))) DIV 28 AS period,
+        repo_id,
+        COUNT(DISTINCT actor_login) AS stars
+    FROM github_events
+    WHERE
+        type = 'WatchEvent'
+        AND action = 'started'
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
         AND created_at > DATE_SUB(CURRENT_DATE(), INTERVAL 56 DAY)
     GROUP BY period, repo_id
 ), stars_last_period AS (
     SELECT
         repo_id,
-        repo_name,
         stars,
         ROW_NUMBER() OVER(ORDER BY stars DESC) AS `rank`
     FROM
@@ -35,7 +33,6 @@ WITH stars_group_by_repo AS (
 ), stars_last_2nd_period AS (
     SELECT
         repo_id,
-        repo_name,
         stars,
         ROW_NUMBER() OVER(ORDER BY stars DESC) AS `rank`
     FROM
@@ -44,17 +41,21 @@ WITH stars_group_by_repo AS (
         period = 1
 )
 SELECT
-    slp.repo_id,
-    slp.repo_name,
+    ci.repo_id,
+    ci.repo_name,
     -- Stars
-    IFNULL(slp.stars, 0) AS last_period_total,
-    IFNULL(slp.`rank`, 0) AS last_period_rank,
-    IFNULL(sl2p.stars, 0) AS last_2nd_period_total,
-    IFNULL(sl2p.`rank`, 0) AS last_2nd_period_rank,
+    IFNULL(slp.stars, 0)                                     AS last_period_total,
+    IFNULL(slp.`rank`, 0)                                    AS last_period_rank,
+    IFNULL(sl2p.stars, 0)                                    AS last_2nd_period_total,
+    IFNULL(sl2p.`rank`, 0)                                   AS last_2nd_period_rank,
+    -- The changes of total stars between two periods.
     IFNULL(((slp.stars - sl2p.stars) / sl2p.stars) * 100, 0) AS total_pop,
-    IFNULL((slp.`rank` - sl2p.`rank`), 0) AS rank_pop,
-    IFNULL(pgr.stars, 0) AS total
-FROM stars_group_by_repo pgr
-JOIN stars_last_period slp ON pgr.repo_id = slp.repo_id
-LEFT JOIN stars_last_2nd_period sl2p ON pgr.repo_id = sl2p.repo_id
+    -- The rank changes between two periods.
+    IFNULL((slp.`rank` - sl2p.`rank`), 0)                    AS rank_pop,
+    -- The total stars of repo.
+    IFNULL(sgr.prs, 0)                                       AS total
+FROM stars_group_by_repo sgr
+JOIN collection_items ci ON ci.collection_id = 10001 AND sgr.repo_id = ci.repo_id
+JOIN stars_last_period slp ON sgr.repo_id = slp.repo_id
+LEFT JOIN stars_last_2nd_period sl2p ON sgr.repo_id = sl2p.repo_id
 ORDER BY last_period_rank;

--- a/configs/queries/collection-stars-last-28-days-rank/template.sql
+++ b/configs/queries/collection-stars-last-28-days-rank/template.sql
@@ -3,6 +3,7 @@ WITH stars_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT actor_login) AS prs
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_actor_login)
     WHERE
         type = 'WatchEvent'
         AND action = 'started'
@@ -14,6 +15,7 @@ WITH stars_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT actor_login) AS stars
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_actor_login)
     WHERE
         type = 'WatchEvent'
         AND action = 'started'

--- a/configs/queries/collection-stars-month-rank/params.json
+++ b/configs/queries/collection-stars-month-rank/params.json
@@ -5,9 +5,7 @@
   "params": [
     {
       "name": "collectionId",
-      "type": "collection",
-      "enums": "collectionIds",
-      "replaces": "41986369, 16563587, 105944401",
+      "replaces": "10001",
       "pattern": "^[1-9]\\d*$"
     }
   ]

--- a/configs/queries/collection-stars-month-rank/template.sql
+++ b/configs/queries/collection-stars-month-rank/template.sql
@@ -44,8 +44,8 @@ WITH stars_group_by_repo AS (
 SELECT
     ci.repo_id,
     ci.repo_name,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01') AS current_month,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01') AS last_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m') AS current_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m') AS last_month,
     -- Stars.
     ilm.stars AS current_month_total,
     ilm.`rank` AS current_month_rank,

--- a/configs/queries/collection-stars-month-rank/template.sql
+++ b/configs/queries/collection-stars-month-rank/template.sql
@@ -3,6 +3,7 @@ WITH stars_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT actor_login) AS prs
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_actor_login)
     WHERE
         type = 'WatchEvent'
         AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
@@ -13,6 +14,7 @@ WITH stars_group_by_repo AS (
         repo_id,
         COUNT(DISTINCT actor_login) AS stars
     FROM github_events
+    USE INDEX (index_ge_on_repo_id_type_action_created_at_actor_login)
     WHERE
         type = 'WatchEvent'
         AND action = 'started'

--- a/configs/queries/collection-stars-month-rank/template.sql
+++ b/configs/queries/collection-stars-month-rank/template.sql
@@ -1,57 +1,64 @@
 WITH stars_group_by_repo AS (
     SELECT
         repo_id,
-        COUNT(actor_login) AS stars
+        COUNT(DISTINCT actor_login) AS prs
     FROM github_events
     WHERE
         type = 'WatchEvent'
-        AND repo_id IN (41986369, 16563587, 105944401)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
     GROUP BY repo_id
 ), stars_group_by_month AS (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') AS event_month,
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
         repo_id,
-        COUNT(actor_login) AS stars
+        COUNT(DISTINCT actor_login) AS stars
     FROM github_events
     WHERE
         type = 'WatchEvent'
         AND action = 'started'
-        AND repo_id IN (41986369, 16563587, 105944401)
+        AND repo_id IN (SELECT repo_id FROM collection_items ci WHERE collection_id = 10001)
         AND created_at < DATE_FORMAT(NOW(), '%Y-%m-01')
         AND created_at >= DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
-    GROUP BY repo_id, DATE_FORMAT(created_at, '%Y-%m-01')
+    GROUP BY t_month, repo_id
 ), stars_last_month AS (
     SELECT
+        t_month,
         repo_id,
         stars,
         ROW_NUMBER() OVER(ORDER BY stars DESC) AS `rank`
-    FROM stars_group_by_month
+    FROM
+        stars_group_by_month sgn
     WHERE
-        event_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01')
+        t_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01')
 ), stars_last_2nd_month AS (
     SELECT
+        t_month,
         repo_id,
         stars,
         ROW_NUMBER() OVER(ORDER BY stars DESC) AS `rank`
-    FROM stars_group_by_month
+    FROM
+        stars_group_by_month sgn
     WHERE
-        event_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
+        t_month = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01')
 )
 SELECT
-    sgr.repo_id,
-    r.repo_name,
-    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL DAYOFMONTH(NOW()) DAY), '%Y-%m') AS current_month,
-    DATE_FORMAT(DATE_SUB(DATE_SUB(NOW(), INTERVAL DAYOFMONTH(NOW()) DAY), INTERVAL 1 MONTH), '%Y-%m') AS last_month,
-    -- Stars
-    slm.stars AS current_month_total,
-    slm.`rank` AS current_month_rank,
-    IFNULL(sl2m.stars, 0) AS last_month_total,
-    sl2m.`rank` AS last_month_rank,
-    ((slm.stars - sl2m.stars) / sl2m.stars) * 100 AS total_mom,
-    (slm.`rank` - sl2m.`rank`) AS rank_mom,
-    sgr.stars AS total
-FROM stars_group_by_repo sgr 
-JOIN stars_last_month slm ON sgr.repo_id = slm.repo_id
-LEFT JOIN stars_last_2nd_month sl2m ON slm.repo_id = sl2m.repo_id
-LEFT JOIN github_repos r ON sgr.repo_id = r.repo_id
+    ci.repo_id,
+    ci.repo_name,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 MONTH), '%Y-%m-01') AS current_month,
+    DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 MONTH), '%Y-%m-01') AS last_month,
+    -- Stars.
+    ilm.stars AS current_month_total,
+    ilm.`rank` AS current_month_rank,
+    IFNULL(il2m.stars, 0) AS last_month_total,
+    il2m.`rank` AS last_month_rank,
+    -- The changes of total stars between the last two periods.
+    ((ilm.stars - il2m.stars) / il2m.stars) * 100 AS total_mom,
+    -- The rank changes between the last two periods.
+    (ilm.`rank` - il2m.`rank`) AS rank_mom,
+    -- The total stars of repo.
+    igr.prs AS total
+FROM stars_group_by_repo igr
+JOIN collection_items ci ON ci.collection_id = 10001 AND igr.repo_id = ci.repo_id
+JOIN stars_last_month ilm ON igr.repo_id = ilm.repo_id
+LEFT JOIN stars_last_2nd_month il2m ON ilm.repo_id = il2m.repo_id
 ORDER BY current_month_rank;

--- a/configs/queries/personal-pull-request-action-history/template.sql
+++ b/configs/queries/personal-pull-request-action-history/template.sql
@@ -13,7 +13,7 @@ WITH user_merged_prs AS (
     ORDER BY 1
 ), user_open_prs AS (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') AS event_month,
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
         COUNT(*) AS cnt
     FROM github_events ge
     WHERE
@@ -26,9 +26,9 @@ WITH user_merged_prs AS (
     ORDER BY 1
 ), event_months AS (
     SELECT
-        DISTINCT event_month
+        DISTINCT t_month
     FROM (
-        SELECT event_month
+        SELECT t_month
         FROM user_open_prs
         UNION
         SELECT event_month
@@ -36,10 +36,10 @@ WITH user_merged_prs AS (
     ) sub
 )
 SELECT
-    m.event_month,
+    m.t_month AS event_month,
     IFNULL(opr.cnt, 0) AS opened_prs,
     IFNULL(mpr.cnt, 0) AS merged_prs
 FROM event_months m
-LEFT JOIN user_open_prs opr ON m.event_month = opr.event_month
-LEFT JOIN user_merged_prs mpr ON m.event_month = mpr.event_month
-ORDER BY event_month
+LEFT JOIN user_open_prs opr ON m.t_month = opr.t_month
+LEFT JOIN user_merged_prs mpr ON m.t_month = mpr.event_month
+ORDER BY m.t_month

--- a/configs/queries/personal-pull-request-reviews-history/template.sql
+++ b/configs/queries/personal-pull-request-reviews-history/template.sql
@@ -1,6 +1,6 @@
 WITH reviews AS (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') AS event_month,
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
         COUNT(*) AS cnt
     FROM github_events ge
     WHERE
@@ -12,7 +12,7 @@ WITH reviews AS (
     ORDER BY 1
 ), review_comments AS (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01') AS event_month,
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
         COUNT(*) AS cnt
     FROM github_events ge
     WHERE
@@ -24,8 +24,8 @@ WITH reviews AS (
     ORDER BY 1
 )
 SELECT
-    r.event_month,
+    r.t_month AS event_month,
     IFNULL(r.cnt, 0) AS reviews,
     IFNULL(rc.cnt, 0) AS review_comments
 FROM reviews r
-JOIN review_comments rc ON r.event_month = rc.event_month
+JOIN review_comments rc ON r.t_month = rc.t_month

--- a/configs/queries/personal-pull-request-size-history/template.sql
+++ b/configs/queries/personal-pull-request-size-history/template.sql
@@ -1,18 +1,18 @@
-SELECT event_month, xs, s, m, l, xl, all_size
+SELECT t_month AS event_month, xs, s, m, l, xl, xxl, all_size
 FROM (
     SELECT
-        event_month,
-        SUM(CASE WHEN changes < 10 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS xs,
-        SUM(CASE WHEN changes >= 10 AND changes < 30 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS s,
-        SUM(CASE WHEN changes >= 30 AND changes < 100 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS m,
-        SUM(CASE WHEN changes >= 100 AND changes < 500 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS l,
-        SUM(CASE WHEN changes >= 500 AND changes < 1000 THEN 1 ELSE 0 END) OVER(PARTITION BY event_month) AS xl,
-        SUM(CASE WHEN changes >= 1000 THEN 1 ELSE 0 END) OVER (PARTITION BY event_month) AS xxl,
-        COUNT(*) OVER (PARTITION BY event_month) AS all_size,
-        ROW_NUMBER() OVER (PARTITION BY event_month) AS row_num
+        t_month,
+        SUM(IF(changes < 10, 1, 0)) OVER(PARTITION BY t_month)                      AS xs,
+        SUM(IF(changes >= 10 AND changes < 30, 1, 0)) OVER(PARTITION BY t_month)    AS s,
+        SUM(IF(changes >= 30 AND changes < 100, 1, 0)) OVER(PARTITION BY t_month)   AS m,
+        SUM(IF(changes >= 100 AND changes < 500, 1, 0)) OVER(PARTITION BY t_month)  AS l,
+        SUM(IF(changes >= 500 AND changes < 1000, 1, 0)) OVER(PARTITION BY t_month) AS xl,
+        SUM(IF(changes >= 1000, 1, 0)) OVER (PARTITION BY t_month)                  AS xxl,
+        COUNT(*) OVER (PARTITION BY t_month)                                        AS all_size,
+        ROW_NUMBER() OVER (PARTITION BY t_month)                                    AS row_num
     FROM (
         SELECT
-            DATE_FORMAT(created_at, '%Y-%m-01') AS event_month,
+            DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
             additions + deletions AS changes
         FROM github_events ge
         WHERE

--- a/configs/queries/pull-request-creators-map/template.sql
+++ b/configs/queries/pull-request-creators-map/template.sql
@@ -8,10 +8,7 @@ WITH group_by_area AS (
         ge.repo_id IN (41986369)
         AND ge.type = 'PullRequestEvent'
         AND ge.action = 'opened'
-        AND gu.country_code IS NOT NULL  -- TODO: remove
-        AND gu.country_code != ''
-        AND gu.country_code != 'N/A'
-        AND gu.country_code != 'UND'
+        AND gu.country_code NOT IN ('', 'N/A', 'UND')
     GROUP BY country_or_area
 ), summary AS (
     SELECT SUM(cnt) AS total FROM group_by_area

--- a/configs/queries/pull-request-creators-per-month/template.sql
+++ b/configs/queries/pull-request-creators-per-month/template.sql
@@ -1,19 +1,9 @@
-WITH prs_with_latest_repo_name AS (
-    SELECT
-        event_month,
-        repo_id,
-        FIRST_VALUE(repo_name) OVER(PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-        actor_login
-    FROM github_events
-    WHERE
-        type = 'PullRequestEvent' and repo_id = 41986369 and action = 'opened'
-), repo_month_group AS (
-    SELECT
-        event_month,
-        repo_name,
-        COUNT(distinct actor_login) as month_pr_count
-    FROM prs_with_latest_repo_name
-    GROUP BY repo_name, event_month
-    ORDER BY 1, 2
-)
-SELECT * FROM repo_month_group;
+SELECT
+    DATE_FORMAT(created_at, '%Y-%m-01') as event_month,
+    COUNT(DISTINCT actor_login) as month_pr_count
+FROM github_events ge
+WHERE
+    type = 'PullRequestEvent'
+    AND repo_id = 41986369
+    AND action = 'opened'
+GROUP BY DATE_FORMAT(created_at, '%Y-%m-01')

--- a/configs/queries/stars-history/template.sql
+++ b/configs/queries/stars-history/template.sql
@@ -1,16 +1,30 @@
-WITH acc AS (
+WITH stars AS (
     SELECT
-        DATE_FORMAT(created_at, '%Y-%m-01')                                    AS t_month,
-        COUNT(actor_login) OVER (ORDER BY DATE_FORMAT(created_at, '%Y-%m-01')) AS total,
-        ROW_NUMBER() OVER (PARTITION BY actor_login)                           AS row_num
+        created_at,
+        ROW_NUMBER() OVER (PARTITION BY actor_login) AS row_num
     FROM github_events
     WHERE
         type = 'WatchEvent'
         AND repo_id = 41986369
+), stars_per_month AS (
+    SELECT
+        DATE_FORMAT(created_at, '%Y-%m-01') AS t_month,
+        COUNT(*) AS total
+    FROM stars
+    WHERE
+        row_num = 1
+    GROUP BY
+        t_month
+), acc AS (
+    SELECT
+        t_month,
+        SUM(total) OVER (ORDER BY t_month) AS total
+    FROM stars_per_month
 )
-SELECT t_month AS event_month, total
+SELECT
+    t_month AS event_month,
+    total
 FROM acc
 GROUP BY t_month
 ORDER BY t_month
 ;
-

--- a/configs/queries/stars-history/template.sql
+++ b/configs/queries/stars-history/template.sql
@@ -1,23 +1,16 @@
 WITH acc AS (
     SELECT
-        event_month,
-        repo_name,
-        COUNT(actor_login) OVER(PARTITION BY repo_name ORDER BY event_month ASC) AS total
-    FROM (
-        SELECT
-            event_month,
-            actor_login,
-            FIRST_VALUE(repo_name) OVER (PARTITION BY repo_id ORDER BY created_at DESC) AS repo_name,
-            ROW_NUMBER() OVER(PARTITION BY actor_login) AS row_num
-        FROM github_events
-        WHERE
-            type = 'WatchEvent' AND repo_id = 41986369
-    ) prs_with_latest_repo_name
-    WHERE row_num = 1
-    ORDER BY 1
+        DATE_FORMAT(created_at, '%Y-%m-01')                                    AS t_month,
+        COUNT(actor_login) OVER (ORDER BY DATE_FORMAT(created_at, '%Y-%m-01')) AS total,
+        ROW_NUMBER() OVER (PARTITION BY actor_login)                           AS row_num
+    FROM github_events
+    WHERE
+        type = 'WatchEvent'
+        AND repo_id = 41986369
 )
-SELECT event_month, ANY_VALUE(repo_name) AS repo_name, ANY_VALUE(total) AS total
+SELECT t_month AS event_month, total
 FROM acc
-GROUP BY 1
-ORDER BY 1
+GROUP BY t_month
+ORDER BY t_month
 ;
+


### PR DESCRIPTION
**What problem does this PR solve?**

Issue Number: part of #969

Problem Summary:

**What is changed and how it works?**