### PR TITLE
Adding network analysis for Kubernetes

### DIFF
--- a/etl/meta/collections/10063.kubernetes-tooling.yml
+++ b/etl/meta/collections/10063.kubernetes-tooling.yml
@@ -24,3 +24,4 @@ items:
   - kubeshop/monokle
   - komodorio/helm-dashboard
   - clastix/capsule
+  - kubeshark/kubeshark


### PR DESCRIPTION
Think TCPDump and Wireshark re-invented for Kubernetes, Kubeshark provides protocol-level visibility into Kubernetes’ internal network, capturing, dissecting and monitoring all traffic and payloads going in, out and across containers, pods, nodes and clusters.

<!--

Thank you for contributing to OSS Insight!

PR Title Format:

Please add the scope of pull request as the title prefix like:

```
<scope>: what's changed.
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add pingcap/tidb repo to open source database collection
```
-->

**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #xxx

Problem Summary:

**What is changed and how it works?**