### PR TITLE
config: add influxdata/influxdb_iox repo to open source database collection

### DIFF
--- a/etl/meta/collections/10042.rust-database.yml
+++ b/etl/meta/collections/10042.rust-database.yml
@@ -19,3 +19,4 @@ items:
   - GreptimeTeam/greptimedb
   - surrealdb/surrealdb
   - cozodb/cozo
+  - influxdata/influxdb_iox


### PR DESCRIPTION
Open source rust databases list was missing influxdata-influxdb_iox repo.

This pull request adds Influxdb IOx to the list of rust databases.
