### PR TITLE
config: add qdrant/qdrant repo to related collections

### DIFF
--- a/etl/meta/collections/10010.artificial-intelligence.yml
+++ b/etl/meta/collections/10010.artificial-intelligence.yml
@@ -36,3 +36,4 @@ items:
   - towhee-io/towhee
   - SeldonIO/seldon-core
   - SeldonIO/MLServer
+  - qdrant/qdrant

--- a/etl/meta/collections/10016.search-engine.yml
+++ b/etl/meta/collections/10016.search-engine.yml
@@ -15,3 +15,4 @@ items:
   - manticoresoftware/manticoresearch
   - semi-technologies/weaviate
   - mosuka/bayard
+  - qdrant/qdrant

--- a/etl/meta/collections/10042.rust-database.yml
+++ b/etl/meta/collections/10042.rust-database.yml
@@ -20,3 +20,4 @@ items:
   - surrealdb/surrealdb
   - cozodb/cozo
   - influxdata/influxdb_iox
+  - qdrant/qdrant

--- a/etl/meta/collections/2.open-source-database.yml
+++ b/etl/meta/collections/2.open-source-database.yml
@@ -38,3 +38,4 @@ items:
   - milvus-io/milvus
   - CUBRID/cubrid
   - GreptimeTeam/greptimedb
+  - qdrant/qdrant


### PR DESCRIPTION
Qdrant (repo: qdrant/qdrant) was missing from the matching categories. It's a Rust vector database / vector search engine and is related to:
- search engines
- open source databases
- rust databases
- AI
Thus, I'm providing an update including Qdrant in all of them.