### PR TITLE
Add `robusta-dev/kubernetes-chatgpt-bot` repo to Kubernetes Tooling collec…

### DIFF
--- a/etl/meta/collections/10063.kubernetes-tooling.yml
+++ b/etl/meta/collections/10063.kubernetes-tooling.yml
@@ -26,3 +26,4 @@ items:
   - clastix/capsule
   - bridgecrewio/checkov
   - kubeshark/kubeshark
+  - robusta-dev/kubernetes-chatgpt-bot


### PR DESCRIPTION


* Add [robusta-dev/kubernetes-chatgpt-bot](https://github.com/robusta-dev/kubernetes-chatgpt-bot) to Kubernetes Tooling collection

This PR adds the Robusta Kubernetes bot to Kubernetes Tooling Collection. 