### PR TITLE
config: Add cloudquery/cloudquery to open source data

### DIFF
--- a/etl/meta/collections/10056.data-integration.yml
+++ b/etl/meta/collections/10056.data-integration.yml
@@ -11,3 +11,4 @@ items:
   - ververica/flink-cdc-connectors
   - apache/inlong
   - bytedance/bitsail
+  - cloudquery/cloudquery


### PR DESCRIPTION
Cloudquery is an airbyte alternative (open source high performance data integration platform).

https://cloudquery.io/