### PR TITLE
user-analyze: use en-US

### DIFF
--- a/web/src/dynamic-pages/analyze-user/Navigator.tsx
+++ b/web/src/dynamic-pages/analyze-user/Navigator.tsx
@@ -76,7 +76,7 @@ export function Navigator ({ value, type, scrollTo }: NavigatorProps) {
 const tabs: Array<{ id: string, label: string, icon?: JSX.Element }> = [
   { id: 'divider-0', label: 'Analytics', icon: <AnalyticsIcon fontSize='inherit' sx={{ mr: 0.5 }} /> },
   { id: 'overview', label: 'Overview' },
-  { id: 'behaviour', label: 'Behaviour' },
+  { id: 'behaviour', label: 'Behavior' },
   { id: 'star', label: 'Star' },
   { id: 'code', label: 'Code' },
   { id: 'code-review', label: 'Code Review' },


### PR DESCRIPTION
It seems to be more relevant in the context of the project to use en-US than en-GB.


---

By the way, we are using the SQL API to create custom metrics for Material UI, it's great :)

App: https://tools-public.onrender.com/prod/pages/9r8fshsf
Source: https://github.com/mui/mui-public/blob/1d5189ff9b50a95a315d5f54269080ef6a57b04c/tools-public/toolpad/queries.ts#L30