### PR TITLE
config: added slim to the security tools collection

### DIFF
--- a/etl/meta/collections/10051.security-tool.yml
+++ b/etl/meta/collections/10051.security-tool.yml
@@ -50,3 +50,4 @@ items:
   - chipsec/chipsec
   - kyverno/kyverno
   - cloudquery/cloudquery
+  - slimtoolkit/slim


### PR DESCRIPTION
Extended the security tool collection adding `slimtoolkit` to it (slimtoolkit can be used to reduce the attack surface in container images, which also reduces the number of vulnerabilities in those container images)