### PR TITLE
Add collection: Networking for Games

### DIFF
--- a/etl/meta/collections/10080.networking-for-games.yml
+++ b/etl/meta/collections/10080.networking-for-games.yml
@@ -1,0 +1,19 @@
+id: 10080
+name: Networking for Games
+items:
+  # javascript
+  - colyseus/colyseus
+  - timetocode/nengi
+
+  # go
+  - heroiclabs/nakama
+
+  # unity
+  - MirrorNetworking/Mirror
+  - Unity-Technologies/com.unity.netcode.gameobjects
+  
+  # low-level
+  - networkprotocol/yojimbo
+  - lsalzman/enet
+  - ValveSoftware/GameNetworkingSockets
+  - RevenantX/LiteNetLib


### PR DESCRIPTION
This is not a complete list. Got some of the items from https://github.com/ThusSpokeNomad/GameNetworkingResources