### PR TITLE
config: Adding gimlet-io/gimlet to kubernetes tooling and cicd collections

### DIFF
--- a/etl/meta/collections/10020.cicd.yml
+++ b/etl/meta/collections/10020.cicd.yml
@@ -23,3 +23,4 @@ items:
   - buildbot/buildbot
   - dagger/dagger
   - bytebase/bytebase
+  - gimlet-io/gimlet

--- a/etl/meta/collections/10063.kubernetes-tooling.yml
+++ b/etl/meta/collections/10063.kubernetes-tooling.yml
@@ -28,3 +28,4 @@ items:
   - kubeshark/kubeshark
   - robusta-dev/kubernetes-chatgpt-bot
   - robusta-dev/krr
+  - gimlet-io/gimlet


### PR DESCRIPTION
Adding gimlet-io/gimlet to Kubernetes tooling and CICD collections.