### PR TITLE
config: add jhasse/jngl and pinguin999/ALPACA repo to game engines

### DIFF
--- a/etl/meta/collections/10013.game-engine.yml
+++ b/etl/meta/collections/10013.game-engine.yml
@@ -61,3 +61,5 @@ items:
   - defold/defold
   - pokepetter/ursina
   - BoomingTech/Piccolo
+  - jhasse/jngl
+  - pinguin999/ALPACA


### PR DESCRIPTION
Add JNGL and ALPACA game engines

What problem does this PR solve?
jhasse/jngl and pinguin999/ALPACA missing as "game engines"

Issue Number: N/A

Problem Summary:

What is changed and how it works?
Add jhasse/jngl and pinguin999/ALPACA as "game engines"