### PR TITLE
api-server: fix the decorator to avoid init playground conn each time

### DIFF
--- a/packages/api-server/src/core/executor/query-executor/TiDBPlaygroundQueryExecutor.ts
+++ b/packages/api-server/src/core/executor/query-executor/TiDBPlaygroundQueryExecutor.ts
@@ -13,9 +13,9 @@ export class TiDBPlaygroundQueryExecutor extends TiDBQueryExecutor {
     connectionLimits: string[] = []
   ) {
     super(pool, shadowPool, pLogger);
-    decoratePoolConnections(this.logger,  this.pool, { initialSql: connectionLimits });
+    decoratePoolConnections(this.logger, this.pool, { initialSql: connectionLimits });
     if (this.shadowPool) {
-      decoratePoolConnections(this.logger,  this.pool,  { initialSql: connectionLimits });
+      decoratePoolConnections(this.logger, this.shadowPool,  { initialSql: connectionLimits });
     }
   }
 }

--- a/packages/api-server/src/plugins/services/explorer-service/index.ts
+++ b/packages/api-server/src/plugins/services/explorer-service/index.ts
@@ -841,7 +841,9 @@ export class ExplorerService {
 
     private shouldSummary(): boolean {
         // Control the summary probability to 2 / 5.
-        return Math.ceil(Math.random() * 100) % 5 >= 3;
+        // return Math.ceil(Math.random() * 100) % 5 >= 3;
+        // Disable summary for now.
+        return false;
     }
 
     private async executeQuery(questionId: string, querySQL: string): Promise<QuestionQueryResult> {


### PR DESCRIPTION
The `PoolConnection` object is a wrapper of the `Connection` object, and a new `PoolConnection` object is created each time the `getConnection` method is executed. The internal `Connection` object is recycled.

Therefore, it is not valid to set the initialized property on the `PoolConnection`, but to set the `Connection` object inside it.