### PR TITLE
config: add hexops/mach repo to open source game engine collection

### DIFF
--- a/etl/meta/collections/10013.game-engine.yml
+++ b/etl/meta/collections/10013.game-engine.yml
@@ -47,6 +47,7 @@ items:
   - cocos-creator/engine
   - coronalabs/corona
   - hajimehoshi/ebiten
+  - hexops/mach
   - HaxeFoundation/haxe
   - Esenthel/EsenthelEngine
   - aws/lumberyard


### PR DESCRIPTION
**What problem does this PR solve?**

Add missing repository to collection.

Problem Summary:

Mach is an up-and-coming Zig game engine.