### PR TITLE
public-api: fix the prefix of public api endpoint

### DIFF
--- a/packages/api-server/src/routes/public/index.ts
+++ b/packages/api-server/src/routes/public/index.ts
@@ -23,7 +23,7 @@ const queryHandler: FastifyPluginAsync = async (app, opts): Promise<void> => {
 
     // Extract query name from URL.
     const url = new URL(req.url, 'http://localhost');
-    const queryName = url.pathname?.replace('/queries/', '');
+    const queryName = url.pathname?.replace('/public/', '');
     if (!queryName) {
       reply.code(400).send({
         error: 'Bad Request',


### PR DESCRIPTION
<!--

Thank you for contributing to OSS Insight!

PR Title Format:

Please add the scope of pull request as the title prefix like:

```
<scope>: what's changed.
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add pingcap/tidb repo to open source database collection
```
-->

**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #xxx

Problem Summary:

**What is changed and how it works?**