### PR TITLE
query: add new query `analyze-repo-top-contributors`

### DIFF
--- a/configs/queries/analyze-repo-top-contributors/params.json
+++ b/configs/queries/analyze-repo-top-contributors/params.json
@@ -1,0 +1,16 @@
+{
+  "cacheHours": 1,
+  "params": [
+    {
+      "name": "repoId",
+      "replaces": "41986369",
+      "pattern": "^[1-9]\\d*$"
+    },
+    {
+      "name": "limit",
+      "replaces": "9999999999",
+      "pattern": "^[1-9]\\d*$",
+      "default": 5
+    }
+  ]
+}

--- a/configs/queries/analyze-repo-top-contributors/template.sql
+++ b/configs/queries/analyze-repo-top-contributors/template.sql
@@ -1,23 +1,18 @@
-WITH contributions AS (
-    SELECT
-        actor_login, COUNT(*) AS events
-    FROM
-        github_events ge
-    WHERE
-        repo_id = 41986369
-        AND (
-            (type = 'PullRequestEvent' AND action = 'opened') OR
-            (type = 'IssuesEvent' AND action = 'opened') OR
-            (type = 'IssueCommentEvent' AND action = 'created') OR
-            (type = 'PullRequestReviewEvent' AND action = 'created') OR
-            (type = 'PullRequestReviewCommentEvent' AND action = 'created') OR
-            (type = 'PushEvent' AND action = '')
-        )
-        AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
-    GROUP BY actor_login
-)
-SELECT actor_login, c.events AS events
-FROM contributions c
+SELECT actor_login,
+       COUNT(*) AS events
+FROM github_events ge
+WHERE repo_id = 41986369
+  AND (
+        (type = 'PullRequestEvent' AND action = 'opened') OR
+        (type = 'IssuesEvent' AND action = 'opened') OR
+        (type = 'IssueCommentEvent' AND action = 'created') OR
+        (type = 'PullRequestReviewEvent' AND action = 'created') OR
+        (type = 'PullRequestReviewCommentEvent' AND action = 'created') OR
+        (type = 'PushEvent' AND action = '')
+    )
+  AND actor_login NOT LIKE '%bot'
+  AND actor_login NOT LIKE '%[bot]'
+  AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
 GROUP BY actor_login
-ORDER BY c.events DESC
+ORDER BY events DESC
 LIMIT 9999999999

--- a/configs/queries/analyze-repo-top-contributors/template.sql
+++ b/configs/queries/analyze-repo-top-contributors/template.sql
@@ -1,0 +1,23 @@
+WITH contributions AS (
+    SELECT
+        actor_login, COUNT(*) AS events
+    FROM
+        github_events ge
+    WHERE
+        repo_id = 41986369
+        AND (
+            (type = 'PullRequestEvent' AND action = 'opened') OR
+            (type = 'IssuesEvent' AND action = 'opened') OR
+            (type = 'IssueCommentEvent' AND action = 'created') OR
+            (type = 'PullRequestReviewEvent' AND action = 'created') OR
+            (type = 'PullRequestReviewCommentEvent' AND action = 'created') OR
+            (type = 'PushEvent' AND action = '')
+        )
+        AND actor_login NOT LIKE '%bot' AND actor_login NOT LIKE '%[bot]' AND actor_login NOT IN (SELECT login FROM blacklist_users bu)
+    GROUP BY actor_login
+)
+SELECT actor_login, c.events AS events
+FROM contributions c
+GROUP BY actor_login
+ORDER BY c.events DESC
+LIMIT 9999999999


### PR DESCRIPTION
This is same to `analyze-recent-top-contributors` without time restrictions. 