### PR TITLE
queries: refine org queries

### DIFF
--- a/configs/queries/orgs/commits/code-changes/top-repos/params.json
+++ b/configs/queries/orgs/commits/code-changes/top-repos/params.json
@@ -26,6 +26,11 @@
       "type": "integer",
       "enums": [5, 10, 20, 30, 40, 50],
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/commits/code-changes/top-repos/template.sql
+++ b/configs/queries/orgs/commits/code-changes/top-repos/template.sql
@@ -18,6 +18,10 @@ WITH repos AS (
         AND type = 'PullRequestEvent'
         AND action = 'closed'
         AND pr_merged = 1
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/commits/time-distribution/params.json
+++ b/configs/queries/orgs/commits/time-distribution/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/commits/time-distribution/template.sql
+++ b/configs/queries/orgs/commits/time-distribution/template.sql
@@ -17,6 +17,10 @@ WHERE
     repo_id IN (SELECT repo_id FROM repos)
     AND type = 'PushEvent'
     AND action = ''
+    {% if excludeBots %}
+    -- Exclude bot users.
+    AND ge.actor_login NOT LIKE '%bot%'
+    {% endif %}
     {% case period %}
         {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
         {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/commits/total/params.json
+++ b/configs/queries/orgs/commits/total/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/commits/total/template.sql
+++ b/configs/queries/orgs/commits/total/template.sql
@@ -21,6 +21,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND type = 'PushEvent'
         AND action = ''
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/commits/trends/params.json
+++ b/configs/queries/orgs/commits/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/commits/trends/template.sql
+++ b/configs/queries/orgs/commits/trends/template.sql
@@ -54,6 +54,10 @@ WITH RECURSIVE seq(idx, day) AS (
             repo_id IN (SELECT repo_id FROM repos)
             AND type = 'PushEvent'
             AND action = ''
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 7 DAY)
                 {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/issues/actions/trends/params.json
+++ b/configs/queries/orgs/issues/actions/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/actions/trends/template.sql
+++ b/configs/queries/orgs/issues/actions/trends/template.sql
@@ -20,6 +20,10 @@ WHERE
     ge.repo_id IN (SELECT repo_id FROM repos)
     AND ge.type = 'IssuesEvent'
     AND ge.action IN ('opened', 'closed')
+    {% if excludeBots %}
+    -- Exclude bot users.
+    AND ge.actor_login NOT LIKE '%bot%'
+    {% endif %}
     {% case period %}
         {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
         {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/issues/closed-ratio/params.json
+++ b/configs/queries/orgs/issues/closed-ratio/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/closed-ratio/template.sql
+++ b/configs/queries/orgs/issues/closed-ratio/template.sql
@@ -27,11 +27,15 @@ WITH repos AS (
             ge.repo_id IN (SELECT repo_id FROM repos)
             AND ge.type = 'IssuesEvent'
             AND ge.action = 'opened'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
-                {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
-                {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)
-                {% when 'past_90_days' %} AND created_at > (NOW() - INTERVAL 180 DAY)
-                {% when 'past_12_months' %} AND created_at > (NOW() - INTERVAL 24 MONTH)
+                {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 14 DAY)
+                {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 56 DAY)
+                {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 180 DAY)
+                {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 24 MONTH)
             {% endcase %}
     ) sub
     WHERE
@@ -61,6 +65,10 @@ WITH repos AS (
             ge.repo_id IN (SELECT repo_id FROM repos)
             AND ge.type = 'IssuesEvent'
             AND ge.action = 'closed'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/issues/issue-comments/top-repos/params.json
+++ b/configs/queries/orgs/issues/issue-comments/top-repos/params.json
@@ -26,6 +26,11 @@
       "type": "integer",
       "enums": [5, 10, 20, 40, 50],
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/issue-comments/top-repos/template.sql
+++ b/configs/queries/orgs/issues/issue-comments/top-repos/template.sql
@@ -15,6 +15,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'IssuesEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/issues/open-to-close-duration/medium/params.json
+++ b/configs/queries/orgs/issues/open-to-close-duration/medium/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/open-to-close-duration/medium/template.sql
+++ b/configs/queries/orgs/issues/open-to-close-duration/medium/template.sql
@@ -65,7 +65,7 @@ WITH repos AS (
     WHERE
         iwc.closed_at > iwo.opened_at
         -- Exclude self-response.
-        AND pwc.closed_by != pwo.opened_by
+        AND iwc.closed_by != iwo.opened_by
 ), current_period_medium AS (
     SELECT
         MAX(hours) AS p50

--- a/configs/queries/orgs/issues/open-to-close-duration/top-repos/params.json
+++ b/configs/queries/orgs/issues/open-to-close-duration/top-repos/params.json
@@ -26,6 +26,11 @@
       "type": "integer",
       "enums": [10, 20, 30, 40, 50],
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/open-to-close-duration/top-repos/template.sql
+++ b/configs/queries/orgs/issues/open-to-close-duration/top-repos/template.sql
@@ -15,11 +15,15 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'IssuesEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
-            {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
-            {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)
-            {% when 'past_90_days' %} AND created_at > (NOW() - INTERVAL 90 DAY)
-            {% when 'past_12_months' %} AND created_at > (NOW() - INTERVAL 12 MONTH)
+            {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
+            {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)
+            {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 90 DAY)
+            {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
         {% endcase %}
 ), issues_with_closed_at AS (
     SELECT
@@ -29,11 +33,15 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'IssuesEvent'
         AND ge.action = 'closed'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
-            {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
-            {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)
-            {% when 'past_90_days' %} AND created_at > (NOW() - INTERVAL 180 DAY)
-            {% when 'past_12_months' %} AND created_at > (NOW() - INTERVAL 24 MONTH)
+            {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 14 DAY)
+            {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 56 DAY)
+            {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 180 DAY)
+            {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 24 MONTH)
         {% endcase %}
 ), tdiff AS (
     SELECT

--- a/configs/queries/orgs/issues/open-to-first-response-duration/medium/params.json
+++ b/configs/queries/orgs/issues/open-to-first-response-duration/medium/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/open-to-first-response-duration/medium/template.sql
+++ b/configs/queries/orgs/issues/open-to-first-response-duration/medium/template.sql
@@ -24,11 +24,15 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'IssuesEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
-            {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
-            {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)
-            {% when 'past_90_days' %} AND created_at > (NOW() - INTERVAL 180 DAY)
-            {% when 'past_12_months' %} AND created_at > (NOW() - INTERVAL 24 MONTH)
+            {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 14 DAY)
+            {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 56 DAY)
+            {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 180 DAY)
+            {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 24 MONTH)
         {% endcase %}
 ), issues_with_first_responsed_at AS (
     SELECT

--- a/configs/queries/orgs/issues/open-to-first-response-duration/top-repos/params.json
+++ b/configs/queries/orgs/issues/open-to-first-response-duration/top-repos/params.json
@@ -26,6 +26,11 @@
       "type": "integer",
       "enums": [10, 20, 30, 40, 50],
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/open-to-first-response-duration/top-repos/template.sql
+++ b/configs/queries/orgs/issues/open-to-first-response-duration/top-repos/template.sql
@@ -18,11 +18,15 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'IssuesEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
-            {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
-            {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)
-            {% when 'past_90_days' %} AND created_at > (NOW() - INTERVAL 90 DAY)
-            {% when 'past_12_months' %} AND created_at > (NOW() - INTERVAL 12 MONTH)
+            {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
+            {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)
+            {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 90 DAY)
+            {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
         {% endcase %}
 ), issues_with_first_response_at AS (
     SELECT
@@ -45,13 +49,15 @@ WITH repos AS (
                 (ge.type = 'IssuesEvent' AND ge.action = 'closed') OR
                 (ge.type = 'IssueCommentEvent' AND ge.action = 'created')
             )
+            {% if excludeBots %}
             -- Exclude bot users.
             AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
-                {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
-                {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)
-                {% when 'past_90_days' %} AND created_at > (NOW() - INTERVAL 90 DAY)
-                {% when 'past_12_months' %} AND created_at > (NOW() - INTERVAL 12 MONTH)
+                {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
+                {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)
+                {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 90 DAY)
+                {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
             {% endcase %}
     ) sub
     WHERE

--- a/configs/queries/orgs/issues/total/params.json
+++ b/configs/queries/orgs/issues/total/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/total/template.sql
+++ b/configs/queries/orgs/issues/total/template.sql
@@ -20,11 +20,15 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'IssuesEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
-            {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
-            {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)
-            {% when 'past_90_days' %} AND created_at > (NOW() - INTERVAL 180 DAY)
-            {% when 'past_12_months' %} AND created_at > (NOW() - INTERVAL 24 MONTH)
+            {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 14 DAY)
+            {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 56 DAY)
+            {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 180 DAY)
+            {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 24 MONTH)
         {% endcase %}
     GROUP BY period
 ), current_period_issues AS (

--- a/configs/queries/orgs/issues/trends/params.json
+++ b/configs/queries/orgs/issues/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/issues/trends/template.sql
+++ b/configs/queries/orgs/issues/trends/template.sql
@@ -70,11 +70,15 @@ WITH RECURSIVE seq(idx, current_period_day, past_period_day) AS (
             repo_id IN (SELECT repo_id FROM repos)
             AND type = 'IssuesEvent'
             AND action = 'opened'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
-                {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
-                {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)
-                {% when 'past_90_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 180 DAY)
-                {% when 'past_12_months' %} AND created_at > (CURRENT_DATE() - INTERVAL 24 MONTH)
+                {% when 'past_7_days' %} AND ge.created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
+                {% when 'past_28_days' %} AND ge.created_at > (CURRENT_DATE() - INTERVAL 56 DAY)
+                {% when 'past_90_days' %} AND ge.created_at > (CURRENT_DATE() - INTERVAL 180 DAY)
+                {% when 'past_12_months' %} AND ge.created_at > (CURRENT_DATE() - INTERVAL 24 MONTH)
             {% endcase %}
         GROUP BY day
         ORDER BY day

--- a/configs/queries/orgs/participants/active/ranking/template.sql
+++ b/configs/queries/orgs/participants/active/ranking/template.sql
@@ -21,6 +21,7 @@ WHERE
         {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
     {% endcase %}
     {% if excludeBots %}
+    -- Exclude bot users.
     AND ge.actor_login NOT LIKE '%bot%'
     {% endif %}
 GROUP BY actor_login

--- a/configs/queries/orgs/participants/active/total/params.json
+++ b/configs/queries/orgs/participants/active/total/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/active/total/template.sql
+++ b/configs/queries/orgs/participants/active/total/template.sql
@@ -21,6 +21,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
         AND ge.action IN ('opened', 'created', '')
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/participants/engagements/params.json
+++ b/configs/queries/orgs/participants/engagements/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/locations/params.json
+++ b/configs/queries/orgs/participants/locations/params.json
@@ -31,6 +31,11 @@
       "name": "n",
       "type": "integer",
       "default": 50
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/locations/template.sql
+++ b/configs/queries/orgs/participants/locations/template.sql
@@ -52,6 +52,10 @@ WHERE
         {% else %}
         AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
         AND ge.action IN ('opened', 'created', '')
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
     {% endcase %}
     {% case period %}
         {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)

--- a/configs/queries/orgs/participants/new/ranking/params.json
+++ b/configs/queries/orgs/participants/new/ranking/params.json
@@ -25,6 +25,11 @@
       "name": "n",
       "type": "integer",
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/new/ranking/template.sql
+++ b/configs/queries/orgs/participants/new/ranking/template.sql
@@ -20,6 +20,10 @@ WITH repos AS (
             {% when 'past_90_days' %} AND ge.created_at < (NOW() - INTERVAL 90 DAY)
             {% when 'past_12_months' %} AND ge.created_at < (NOW() - INTERVAL 12 MONTH)
         {% endcase %}
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
     GROUP BY actor_login
 )
 SELECT

--- a/configs/queries/orgs/participants/new/total/params.json
+++ b/configs/queries/orgs/participants/new/total/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/new/total/template.sql
+++ b/configs/queries/orgs/participants/new/total/template.sql
@@ -35,6 +35,10 @@ WITH repos AS (
             {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 90 DAY)
             {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
         {% endcase %}
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         AND NOT EXISTS (
             SELECT 1
             FROM old_participants op
@@ -54,6 +58,10 @@ WITH repos AS (
             {% when 'past_90_days' %} AND ge.created_at BETWEEN (NOW() - INTERVAL 180 DAY) AND (NOW() - INTERVAL 90 DAY)
             {% when 'past_12_months' %} AND ge.created_at BETWEEN (NOW() - INTERVAL 24 MONTH) AND (NOW() - INTERVAL 12 MONTH)
         {% endcase %}
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         AND NOT EXISTS (
             SELECT 1
             FROM old_participants op

--- a/configs/queries/orgs/participants/organizations/params.json
+++ b/configs/queries/orgs/participants/organizations/params.json
@@ -31,6 +31,11 @@
       "name": "n",
       "type": "integer",
       "default": 50
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/organizations/template.sql
+++ b/configs/queries/orgs/participants/organizations/template.sql
@@ -52,7 +52,11 @@ WHERE
         {% else %}
         AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
         AND ge.action IN ('opened', 'created', '')
-    {% endcase %}
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
+        {% endcase %}
     {% case period %}
         {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
         {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/participants/roles/params.json
+++ b/configs/queries/orgs/participants/roles/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/roles/template.sql
+++ b/configs/queries/orgs/participants/roles/template.sql
@@ -14,6 +14,10 @@ WITH repos AS (
         repo_id IN (SELECT repo_id FROM repos)
         AND ge.type ='PullRequestEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/participants/trends/params.json
+++ b/configs/queries/orgs/participants/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/trends/template.sql
+++ b/configs/queries/orgs/participants/trends/template.sql
@@ -1,17 +1,29 @@
-WITH RECURSIVE seq(idx, day) AS (
+WITH RECURSIVE seq(idx, current_period_day, past_period_day) AS (
     SELECT
         1 AS idx,
         {% case period %}
-            {% when 'past_7_days', 'past_28_days', 'past_90_days' %} CURRENT_DATE()
+            {% when 'past_7_days', 'past_28_days', 'past_90_days' %} DATE_FORMAT(CURRENT_DATE(), '%Y-%m-%d')
             {% when 'past_12_months' %} DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
-        {% endcase %} AS day
+        {% endcase %} AS current_period_day,
+        {% case period %}
+            {% when 'past_7_days' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY), '%Y-%m-%d')
+            {% when 'past_28_days' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 28 DAY), '%Y-%m-%d')
+            {% when 'past_90_days' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY), '%Y-%m-%d')
+            {% when 'past_12_months' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 12 MONTH), '%Y-%m-01')
+        {% endcase %} AS past_period_day
     UNION ALL
     SELECT
         idx + 1 AS idx,
         {% case period %}
-            {% when 'past_7_days', 'past_28_days', 'past_90_days' %} DATE_SUB(CURRENT_DATE(), INTERVAL idx day)
+            {% when 'past_7_days', 'past_28_days', 'past_90_days' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL idx DAY), '%Y-%m-%d')
             {% when 'past_12_months' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL idx MONTH), '%Y-%m-01')
-        {% endcase %} AS day
+        {% endcase %} AS current_period_day,
+        {% case period %}
+            {% when 'past_7_days' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL idx + 7 DAY), '%Y-%m-%d')
+            {% when 'past_28_days' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL idx + 28 DAY), '%Y-%m-%d')
+            {% when 'past_90_days' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL idx + 90 DAY), '%Y-%m-%d')
+            {% when 'past_12_months' %} DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL idx + 12 MONTH), '%Y-%m-01')
+        {% endcase %} AS past_period_day
     FROM seq
     WHERE
         1 = 1
@@ -29,78 +41,66 @@ WITH RECURSIVE seq(idx, day) AS (
         {% if repoIds.size > 0 %}
         AND gr.repo_id IN ({{ repoIds | join: ',' }})
         {% endif %}
-), old_participants AS (
-    SELECT
-        actor_login, MIN(created_at) AS first_participant_at
-    FROM github_events ge
-    WHERE
-        ge.repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
-        {% case period %}
-            {% when 'past_7_days' %} AND ge.created_at < (NOW() - INTERVAL 7 DAY)
-            {% when 'past_28_days' %} AND ge.created_at < (NOW() - INTERVAL 28 DAY)
-            {% when 'past_90_days' %} AND ge.created_at < (NOW() - INTERVAL 90 DAY)
-            {% when 'past_12_months' %} AND ge.created_at < (NOW() - INTERVAL 12 MONTH)
-        {% endcase %}
-    GROUP BY actor_login
-), active_participants_per_day AS (
+), group_by_day AS (
     SELECT
         {% case period %}
-            {% when 'past_7_days', 'past_28_days', 'past_90_days' %} DATE_FORMAT(created_at, '%Y-%m-%d')
-            {% when 'past_12_months' %} DATE_FORMAT(created_at, '%Y-%m-01')
-        {% endcase %} AS day,
-        COUNT(DISTINCT actor_login) AS active_participants
-    FROM github_events ge
-    WHERE
-        repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+            {% when 'past_7_days' %} TIMESTAMPDIFF(DAY, day, CURRENT_DATE()) % 7 + 1
+            {% when 'past_28_days' %} TIMESTAMPDIFF(DAY, day, CURRENT_DATE()) % 28 + 1
+            {% when 'past_90_days' %} TIMESTAMPDIFF(DAY, day, CURRENT_DATE()) % 90 + 1
+            {% when 'past_12_months' %} TIMESTAMPDIFF(MONTH, day, CURRENT_DATE()) % 12 + 1
+        {% endcase %} AS idx,
+        -- Divide periods.
         {% case period %}
-            {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 7 DAY)
-            {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 28 DAY)
-            {% when 'past_90_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 90 DAY)
-            {% when 'past_12_months' %} AND created_at > (CURRENT_DATE() - INTERVAL 12 MONTH)
-        {% endcase %}
-    GROUP BY day
-    ORDER BY day
-), new_participants_per_day AS (
-    SELECT
-        {% case period %}
-            {% when 'past_7_days', 'past_28_days', 'past_90_days' %} DATE_FORMAT(first_engagement_at, '%Y-%m-%d')
-            {% when 'past_12_months' %} DATE_FORMAT(first_engagement_at, '%Y-%m-01')
-        {% endcase %} AS day,
-        COUNT(DISTINCT actor_login) AS new_participants
+            {% when 'past_7_days' %} TIMESTAMPDIFF(DAY, day, CURRENT_DATE()) DIV 7
+            {% when 'past_28_days' %} TIMESTAMPDIFF(DAY, day, CURRENT_DATE()) DIV 28
+            {% when 'past_90_days' %} TIMESTAMPDIFF(DAY, day, CURRENT_DATE()) DIV 90
+            {% when 'past_12_months' %} TIMESTAMPDIFF(MONTH, day, CURRENT_DATE()) DIV 12
+        {% endcase %} AS period,
+        day,
+        participants
     FROM (
         SELECT
-            actor_login,
-            MIN(created_at) AS first_engagement_at
-        FROM github_events ge
+            {% case period %}
+                {% when 'past_7_days', 'past_28_days', 'past_90_days' %} DATE_FORMAT(created_at, '%Y-%m-%d')
+                {% when 'past_12_months' %} DATE_FORMAT(created_at, '%Y-%m-01')
+            {% endcase %} AS day,
+            COUNT(*) AS participants
+        FROM
+            github_events ge
         WHERE
             repo_id IN (SELECT repo_id FROM repos)
             AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
             AND ge.action IN ('opened', 'created', '')
             {% case period %}
-                {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 7 DAY)
-                {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 28 DAY)
-                {% when 'past_90_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 90 DAY)
-                {% when 'past_12_months' %} AND created_at > (CURRENT_DATE() - INTERVAL 12 MONTH)
+                {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
+                {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)
+                {% when 'past_90_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 180 DAY)
+                {% when 'past_12_months' %} AND created_at > (CURRENT_DATE() - INTERVAL 24 MONTH)
             {% endcase %}
-            AND NOT EXISTS (
-                SELECT 1
-                FROM old_participants op
-                WHERE op.actor_login = ge.actor_login
-            )
-        GROUP BY actor_login
-    ) AS participant_with_first_engagement
-    GROUP BY day
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
+        GROUP BY day
+        ORDER BY day
+    ) sub
+), current_period AS (
+    SELECT idx, day, participants
+    FROM group_by_day
+    WHERE period = 0
+), past_period AS (
+    SELECT idx, day, participants
+    FROM group_by_day
+    WHERE period = 1
 )
 SELECT
-    s.day,
-    appd.active_participants,
-    nppd.new_participants
+    s.idx AS idx,
+    s.current_period_day AS current_period_day,
+    IFNULL(cp.participants, 0) AS current_period_day_total,
+    s.past_period_day AS past_period_day,
+    IFNULL(pp.participants, 0) AS past_period_day_total
 FROM seq s
-LEFT JOIN active_participants_per_day appd ON s.day = appd.day
-LEFT JOIN new_participants_per_day nppd ON s.day = nppd.day
-ORDER BY s.day
+LEFT JOIN current_period cp ON s.idx = cp.idx
+LEFT JOIN past_period pp ON s.idx = pp.idx
+ORDER BY idx
 ;

--- a/configs/queries/orgs/pull-requests/actions/trends/params.json
+++ b/configs/queries/orgs/pull-requests/actions/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/actions/trends/template.sql
+++ b/configs/queries/orgs/pull-requests/actions/trends/template.sql
@@ -25,6 +25,10 @@ WHERE
     ge.repo_id IN (SELECT repo_id FROM repos)
     AND ge.type = 'PullRequestEvent'
     AND ge.action IN ('opened', 'closed')
+    {% if excludeBots %}
+    -- Exclude bot users.
+    AND ge.actor_login NOT LIKE '%bot%'
+    {% endif %}
     {% case period %}
         {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
         {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/pull-requests/merged-ratio/params.json
+++ b/configs/queries/orgs/pull-requests/merged-ratio/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/merged-ratio/template.sql
+++ b/configs/queries/orgs/pull-requests/merged-ratio/template.sql
@@ -27,6 +27,10 @@ WITH repos AS (
             ge.repo_id IN (SELECT repo_id FROM repos)
             AND ge.type = 'PullRequestEvent'
             AND ge.action = 'opened'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/pull-requests/open-to-close-duration/medium/params.json
+++ b/configs/queries/orgs/pull-requests/open-to-close-duration/medium/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/open-to-close-duration/top-repos/params.json
+++ b/configs/queries/orgs/pull-requests/open-to-close-duration/top-repos/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/open-to-close-duration/top-repos/template.sql
+++ b/configs/queries/orgs/pull-requests/open-to-close-duration/top-repos/template.sql
@@ -15,6 +15,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'PullRequestEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)
@@ -30,6 +34,10 @@ WITH repos AS (
         -- Pull request being closed or merged.
         AND ge.type = 'PullRequestEvent'
         AND ge.action = 'closed'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/pull-requests/open-to-first-response-duration/medium/params.json
+++ b/configs/queries/orgs/pull-requests/open-to-first-response-duration/medium/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/open-to-first-response-duration/medium/template.sql
+++ b/configs/queries/orgs/pull-requests/open-to-first-response-duration/medium/template.sql
@@ -45,8 +45,10 @@ WITH repos AS (
             (ge.type = 'PullRequestReviewEvent' AND ge.action = 'created') OR
             (ge.type = 'IssueCommentEvent' AND ge.action = 'created')
         )
+        {% if excludeBots %}
         -- Exclude bot users.
         AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/pull-requests/open-to-first-response-duration/top-repos/params.json
+++ b/configs/queries/orgs/pull-requests/open-to-first-response-duration/top-repos/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/open-to-first-response-duration/top-repos/template.sql
+++ b/configs/queries/orgs/pull-requests/open-to-first-response-duration/top-repos/template.sql
@@ -46,8 +46,10 @@ WITH repos AS (
                 (ge.type = 'PullRequestReviewEvent' AND ge.action = 'created') OR
                 (ge.type = 'IssueCommentEvent' AND ge.action = 'created')
             )
+            {% if excludeBots %}
             -- Exclude bot users.
             AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
                 {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/pull-requests/total/params.json
+++ b/configs/queries/orgs/pull-requests/total/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/total/template.sql
+++ b/configs/queries/orgs/pull-requests/total/template.sql
@@ -20,6 +20,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'PullRequestEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/pull-requests/trends/params.json
+++ b/configs/queries/orgs/pull-requests/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/trends/template.sql
+++ b/configs/queries/orgs/pull-requests/trends/template.sql
@@ -70,6 +70,10 @@ WITH RECURSIVE seq(idx, current_period_day, past_period_day) AS (
             repo_id IN (SELECT repo_id FROM repos)
             AND type = 'PullRequestEvent'
             AND action = 'opened'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/reviews/open-to-first-review-duration/medium/params.json
+++ b/configs/queries/orgs/reviews/open-to-first-review-duration/medium/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/reviews/open-to-first-review-duration/top-repos/params.json
+++ b/configs/queries/orgs/reviews/open-to-first-review-duration/top-repos/params.json
@@ -26,6 +26,11 @@
       "type": "integer",
       "enums": [5, 10, 20, 40, 50],
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/reviews/open-to-first-review-duration/top-repos/template.sql
+++ b/configs/queries/orgs/reviews/open-to-first-review-duration/top-repos/template.sql
@@ -18,6 +18,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'PullRequestEvent'
         AND ge.action = 'opened'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)
@@ -43,8 +47,10 @@ WITH repos AS (
             -- Events that are considered as first review.
             AND ge.type = 'PullRequestReviewEvent'
             AND ge.action = 'created'
+            {% if excludeBots %}
             -- Exclude bot users.
             AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
                 {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/reviews/review-comments/top-repos/params.json
+++ b/configs/queries/orgs/reviews/review-comments/top-repos/params.json
@@ -26,6 +26,11 @@
       "type": "integer",
       "enums": [5, 10, 20, 40, 50],
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/reviews/review-comments/top-repos/template.sql
+++ b/configs/queries/orgs/reviews/review-comments/top-repos/template.sql
@@ -15,6 +15,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'PullRequestReviewEvent'
         AND ge.action = 'created'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)
@@ -30,6 +34,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'PullRequestReviewCommentEvent'
         AND ge.action = 'created'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/reviews/review-prs/trends/params.json
+++ b/configs/queries/orgs/reviews/review-prs/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/reviews/review-prs/trends/template.sql
+++ b/configs/queries/orgs/reviews/review-prs/trends/template.sql
@@ -70,6 +70,10 @@ WITH RECURSIVE seq(idx, current_period_day, past_period_day) AS (
             repo_id IN (SELECT repo_id FROM repos)
             AND type = 'PullRequestReviewEvent'
             AND action = 'created'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/reviews/reviewed-ratio/params.json
+++ b/configs/queries/orgs/reviews/reviewed-ratio/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/reviews/reviewed-ratio/template.sql
+++ b/configs/queries/orgs/reviews/reviewed-ratio/template.sql
@@ -27,6 +27,10 @@ WITH repos AS (
             ge.repo_id IN (SELECT repo_id FROM repos)
             AND ge.type = 'PullRequestEvent'
             AND ge.action = 'opened'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)
@@ -61,6 +65,10 @@ WITH repos AS (
             ge.repo_id IN (SELECT repo_id FROM repos)
             AND ge.type = 'PullRequestReviewEvent'
             AND ge.action = 'created'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/reviews/total/params.json
+++ b/configs/queries/orgs/reviews/total/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/reviews/total/template.sql
+++ b/configs/queries/orgs/reviews/total/template.sql
@@ -20,6 +20,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'PullRequestReviewEvent'
         AND ge.action = 'created'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/reviews/trends/params.json
+++ b/configs/queries/orgs/reviews/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/reviews/trends/template.sql
+++ b/configs/queries/orgs/reviews/trends/template.sql
@@ -70,6 +70,10 @@ WITH RECURSIVE seq(idx, current_period_day, past_period_day) AS (
             repo_id IN (SELECT repo_id FROM repos)
             AND type = 'PullRequestReviewEvent'
             AND action = 'created'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/stars/locations/params.json
+++ b/configs/queries/orgs/stars/locations/params.json
@@ -25,6 +25,11 @@
       "name": "n",
       "type": "integer",
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/stars/locations/template.sql
+++ b/configs/queries/orgs/stars/locations/template.sql
@@ -17,6 +17,10 @@ WHERE
     ge.repo_id IN (SELECT repo_id FROM repos)
     AND ge.type = 'WatchEvent'
     AND ge.action = 'started'
+    {% if excludeBots %}
+    -- Exclude bot users.
+    AND ge.actor_login NOT LIKE '%bot%'
+    {% endif %}
     {% case period %}
         {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
         {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/stars/organizations/params.json
+++ b/configs/queries/orgs/stars/organizations/params.json
@@ -25,6 +25,11 @@
       "name": "n",
       "type": "integer",
       "default": 10
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/stars/organizations/template.sql
+++ b/configs/queries/orgs/stars/organizations/template.sql
@@ -17,6 +17,10 @@ WHERE
     ge.repo_id IN (SELECT repo_id FROM repos)
     AND ge.type = 'WatchEvent'
     AND ge.action = 'started'
+    {% if excludeBots %}
+    -- Exclude bot users.
+    AND ge.actor_login NOT LIKE '%bot%'
+    {% endif %}
     {% case period %}
         {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
         {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/stars/top-repos/params.json
+++ b/configs/queries/orgs/stars/top-repos/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/stars/top-repos/template.sql
+++ b/configs/queries/orgs/stars/top-repos/template.sql
@@ -16,6 +16,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'WatchEvent'
         AND ge.action = 'started'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/stars/total/params.json
+++ b/configs/queries/orgs/stars/total/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/stars/total/template.sql
+++ b/configs/queries/orgs/stars/total/template.sql
@@ -21,6 +21,10 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND type = 'WatchEvent'
         AND action = 'started'
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/stars/trends/params.json
+++ b/configs/queries/orgs/stars/trends/params.json
@@ -20,6 +20,11 @@
       "type": "string",
       "enums": ["past_7_days", "past_28_days", "past_90_days", "past_12_months"],
       "default": "past_28_days"
+    },
+    {
+      "name": "excludeBots",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/stars/trends/template.sql
+++ b/configs/queries/orgs/stars/trends/template.sql
@@ -71,6 +71,10 @@ WITH RECURSIVE seq(idx, current_period_day, past_period_day) AS (
             repo_id IN (SELECT repo_id FROM repos)
             AND type = 'WatchEvent'
             AND action = 'started'
+            {% if excludeBots %}
+            -- Exclude bot users.
+            AND ge.actor_login NOT LIKE '%bot%'
+            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)

--- a/packages/api-server/README.md
+++ b/packages/api-server/README.md
@@ -2,7 +2,7 @@
 
 This project is the API server of OSS Insight.
 
-## Quick Start
+## Getting started
 
 ### Config Environment Variables
 


### PR DESCRIPTION
- Add `excludeBots` option for all org queries (default: true)
- return  `participant_logins` (A string separated with commas) for query [/orgs/participants/engagements](https://github.com/pingcap/ossinsight/pull/1616/files#diff-d0be74d96faf93ec47f5685bbb8354aa4ce410e34492cbfbcc18e0dbdc3c7316)
- refactor the `/orgs/participants/trends` query