### PR TITLE
queries: refine org queries 2

### DIFF
--- a/configs/queries/orgs/issues/closed-ratio/template.sql
+++ b/configs/queries/orgs/issues/closed-ratio/template.sql
@@ -8,7 +8,7 @@ WITH repos AS (
         {% endif %}
 ), opened_issues AS (
     SELECT
-        sub.repo_id, sub.number, sub.opened_actor_login, sub.opened_at,
+        sub.repo_id, sub.number, sub.opened_by, sub.opened_at,
         {% case period %}
             {% when 'past_7_days' %} TIMESTAMPDIFF(DAY, opened_at, NOW()) DIV 7
             {% when 'past_28_days' %} TIMESTAMPDIFF(DAY, opened_at, NOW()) DIV 28
@@ -19,7 +19,7 @@ WITH repos AS (
          SELECT
              ge.repo_id,
              ge.number,
-             ge.actor_login AS opened_actor_login,
+             ge.actor_login AS opened_by,
              ge.created_at AS opened_at,
              ROW_NUMBER() OVER (PARTITION BY ge.repo_id, ge.number ORDER BY ge.created_at) AS times
          FROM github_events ge
@@ -32,10 +32,10 @@ WITH repos AS (
             AND ge.actor_login NOT LIKE '%bot%'
             {% endif %}
             {% case period %}
-                {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 14 DAY)
-                {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 56 DAY)
-                {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 180 DAY)
-                {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 24 MONTH)
+                {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
+                {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)
+                {% when 'past_90_days' %} AND created_at > (NOW() - INTERVAL 180 DAY)
+                {% when 'past_12_months' %} AND created_at > (NOW() - INTERVAL 24 MONTH)
             {% endcase %}
     ) sub
     WHERE
@@ -45,8 +45,9 @@ WITH repos AS (
     SELECT
         sub.repo_id,
         sub.number,
-        sub.closer_login,
+        sub.closed_by,
         sub.closed_at,
+        IF(sub.closed_by = oi.opened_by, 'self-closed', 'others-closed') AS type,
         {% case period %}
             {% when 'past_7_days' %} TIMESTAMPDIFF(DAY, closed_at, NOW()) DIV 7
             {% when 'past_28_days' %} TIMESTAMPDIFF(DAY, closed_at, NOW()) DIV 28
@@ -57,7 +58,7 @@ WITH repos AS (
         SELECT
             ge.repo_id,
             ge.number,
-            ge.actor_login AS closer_login,
+            ge.actor_login AS closed_by,
             ge.created_at AS closed_at,
             ROW_NUMBER() OVER (PARTITION BY ge.repo_id, ge.number ORDER BY ge.created_at) AS times
         FROM github_events ge
@@ -65,10 +66,6 @@ WITH repos AS (
             ge.repo_id IN (SELECT repo_id FROM repos)
             AND ge.type = 'IssuesEvent'
             AND ge.action = 'closed'
-            {% if excludeBots %}
-            -- Exclude bot users.
-            AND ge.actor_login NOT LIKE '%bot%'
-            {% endif %}
             {% case period %}
                 {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 56 DAY)
@@ -76,38 +73,43 @@ WITH repos AS (
                 {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 24 MONTH)
             {% endcase %}
     ) sub
-    # Only consider closed issues that were opened in the last 28 days.
-    JOIN opened_issues op USING (repo_id, number)
+    # Only consider closed issues that were opened in the period.
+    JOIN opened_issues oi USING (repo_id, number)
     WHERE
         # Only consider the first closed event.
         sub.times = 1
-), opened_issues_per_period AS (
-    SELECT op.period, COUNT(*) AS opened_issues
-    FROM opened_issues op
-    GROUP BY op.period
-), closed_issues_per_period AS (
-    SELECT rp.period, COUNT(*) AS closed_issues
-    FROM closed_issues rp
-    GROUP BY rp.period
-), current_period_opened_issues AS (
-    SELECT * FROM opened_issues_per_period WHERE period = 0
-), past_period_opened_issues AS (
-    SELECT * FROM opened_issues_per_period WHERE period = 1
-), current_period_closed_issues AS (
-    SELECT * FROM closed_issues_per_period WHERE period = 0
-), past_period_closed_issues AS (
-    SELECT * FROM closed_issues_per_period WHERE period = 1
+), issues_per_type AS (
+    (
+        SELECT 'un-closed' AS type, oi.period, COUNT(*) AS issues
+        FROM opened_issues oi
+        LEFT JOIN closed_issues ci USING (repo_id, number)
+        WHERE ci.number IS NULL
+        GROUP BY oi.period
+    )
+    UNION ALL
+    (
+        SELECT type, ci.period, COUNT(*) AS issues
+        FROM closed_issues ci
+        GROUP BY type, ci.period
+    )
+), current_period_issues_per_type AS (
+    SELECT * FROM issues_per_type WHERE period = 0
+), past_period_issues_per_type AS (
+    SELECT * FROM issues_per_type WHERE period = 1
+), current_period_issues_total AS (
+    SELECT SUM(issues) AS issues_total FROM current_period_issues_per_type
+), past_period_issues_total AS (
+    SELECT SUM(issues) AS issues_total FROM past_period_issues_per_type
 )
 SELECT
-    cpoi.opened_issues AS current_period_opened_issues,
-    cpci.closed_issues AS current_period_closed_issues,
-    ROUND(cpci.closed_issues / cpoi.opened_issues, 2) AS current_period_closed_ratio,
-    ppoi.opened_issues AS past_period_opened_issues,
-    ppci.closed_issues AS past_period_closed_issues,
-    ROUND(ppci.closed_issues / ppoi.opened_issues, 2) AS past_period_closed_ratio,
-    ROUND((cpci.closed_issues / cpoi.opened_issues) - (ppci.closed_issues / ppoi.opened_issues), 2) AS closed_ratio_change
-FROM current_period_opened_issues cpoi
-LEFT JOIN current_period_closed_issues cpci ON 1 = 1
-LEFT JOIN past_period_opened_issues ppoi ON 1 = 1
-LEFT JOIN past_period_closed_issues ppci ON 1 = 1
-;
+    cpppt.type,
+    cpppt.issues AS current_period_issues,
+    ROUND(cpppt.issues / cppt.issues_total * 100, 2) AS current_period_percentage,
+    ppppt.issues AS past_period_issues,
+    ROUND(ppppt.issues / pppt.issues_total * 100, 2) AS past_period_percentage,
+    ROUND((cpppt.issues / cppt.issues_total - ppppt.issues / pppt.issues_total) * 100, 2) AS percentage_change
+FROM current_period_issues_per_type cpppt
+LEFT JOIN past_period_issues_per_type ppppt ON cpppt.type = ppppt.type
+LEFT JOIN current_period_issues_total cppt ON 1 = 1
+LEFT JOIN past_period_issues_total pppt ON 1 = 1
+ORDER BY cpppt.issues DESC;

--- a/configs/queries/orgs/issues/open-to-close-duration/medium/params.json
+++ b/configs/queries/orgs/issues/open-to-close-duration/medium/params.json
@@ -24,7 +24,7 @@
     {
       "name": "excludeBots",
       "type": "boolean",
-      "default": true
+      "default": false
     }
   ]
 }

--- a/configs/queries/orgs/overview/template.sql
+++ b/configs/queries/orgs/overview/template.sql
@@ -2,27 +2,47 @@ WITH org AS (
     SELECT id
     FROM github_users
     -- Note: Calculated only when there is no value for stars_total and participant_total.
-    WHERE id = {{ownerId}} AND stars_total IS NULL OR participant_total IS NULL
+    WHERE
+        id = {{ownerId}}
+        AND (stars_total IS NULL OR participant_total IS NULL)
 ), repos AS (
     SELECT repo_id
     FROM github_repos gr
     WHERE gr.owner_id = (SELECT id FROM org LIMIT 1)
-), stars_summary AS (
-    SELECT SUM(stars) AS stars
+), repo_total AS (
+    SELECT COUNT(*) AS repos FROM repos
+), repo_summary AS (
+    SELECT
+        SUM(stars) AS stars
     FROM github_repos gr
     WHERE gr.owner_id = (SELECT id FROM org LIMIT 1)
 ), participant_summary AS (
-    SELECT COUNT(DISTINCT ge.actor_login) AS participants
+    SELECT
+        COUNT(DISTINCT ge.actor_login) AS participants
     FROM github_events ge
     WHERE
         ge.repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
+), participant_last_event AS (
+    SELECT
+        MAX(ge.created_at) AS last_participated_at
+    FROM github_events ge
+    WHERE
+        ge.repo_id IN (SELECT repo_id FROM github_repos WHERE owner_id = {{ownerId}})
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
 )
 SELECT
-    IFNULL(gu.stars_total, ss.stars) AS stars,
-    IFNULL(gu.participant_total, ps.participants) AS participants
-FROM
-    github_users gu, stars_summary ss, participant_summary ps
-WHERE
-    id = {{ownerId}}
+    GREATEST(gu.public_repos, rt.repos) AS public_repos,
+    IFNULL(gu.stars_total, rs.stars) AS stars,
+    IFNULL(gu.participant_total, ps.participants) AS participants,
+    ple.last_participated_at
+FROM github_users gu
+LEFT JOIN repo_total rt ON 1 = 1
+LEFT JOIN repo_summary rs ON 1 = 1
+LEFT JOIN participant_summary ps ON 1 = 1
+LEFT JOIN participant_last_event ple ON 1 = 1
+WHERE id = {{ownerId}}

--- a/configs/queries/orgs/participants/active/ranking/template.sql
+++ b/configs/queries/orgs/participants/active/ranking/template.sql
@@ -12,8 +12,9 @@ SELECT
 FROM github_events ge
 WHERE
     ge.repo_id IN (SELECT repo_id FROM repos)
-    AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-    AND ge.action IN ('opened', 'created', '')
+    -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+    AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+    AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
     {% case period %}
         {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
         {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/participants/active/total/template.sql
+++ b/configs/queries/orgs/participants/active/total/template.sql
@@ -19,8 +19,9 @@ WITH repos AS (
     FROM github_events ge
     WHERE
         ge.repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
         {% if excludeBots %}
         -- Exclude bot users.
         AND ge.actor_login NOT LIKE '%bot%'

--- a/configs/queries/orgs/participants/engagements/template.sql
+++ b/configs/queries/orgs/participants/engagements/template.sql
@@ -15,8 +15,9 @@ WITH repos AS (
     FROM github_events ge
     WHERE
         repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
         {% if excludeBots %}
         -- Exclude bot users.
         AND ge.actor_login NOT LIKE '%bot%'

--- a/configs/queries/orgs/participants/locations/filled-ratio/params.json
+++ b/configs/queries/orgs/participants/locations/filled-ratio/params.json
@@ -24,17 +24,7 @@
     {
       "name": "n",
       "type": "integer",
-      "default": 255
-    },
-    {
-      "name": "excludeBots",
-      "type": "boolean",
-      "default": true
-    },
-    {
-      "name": "excludeUnknown",
-      "type": "boolean",
-      "default": true
+      "default": 10
     }
   ]
 }

--- a/configs/queries/orgs/participants/locations/params.json
+++ b/configs/queries/orgs/participants/locations/params.json
@@ -36,6 +36,11 @@
       "name": "excludeBots",
       "type": "boolean",
       "default": true
+    },
+    {
+      "name": "excludeUnknown",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/locations/template.sql
+++ b/configs/queries/orgs/participants/locations/template.sql
@@ -50,8 +50,9 @@ WHERE
                 AND ge2.number = ge.number
             )
         {% else %}
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
         {% if excludeBots %}
         -- Exclude bot users.
         AND ge.actor_login NOT LIKE '%bot%'

--- a/configs/queries/orgs/participants/new/ranking/template.sql
+++ b/configs/queries/orgs/participants/new/ranking/template.sql
@@ -12,8 +12,9 @@ WITH repos AS (
     FROM github_events ge
     WHERE
         ge.repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
         {% case period %}
             {% when 'past_7_days' %} AND ge.created_at < (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND ge.created_at < (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/participants/new/total/template.sql
+++ b/configs/queries/orgs/participants/new/total/template.sql
@@ -12,8 +12,9 @@ WITH repos AS (
     FROM github_events ge
     WHERE
         ge.repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
         {% case period %}
             {% when 'past_7_days' %} AND ge.created_at < (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND ge.created_at < (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/participants/organizations/filled-ratio/params.json
+++ b/configs/queries/orgs/participants/organizations/filled-ratio/params.json
@@ -24,17 +24,7 @@
     {
       "name": "n",
       "type": "integer",
-      "default": 255
-    },
-    {
-      "name": "excludeBots",
-      "type": "boolean",
-      "default": true
-    },
-    {
-      "name": "excludeUnknown",
-      "type": "boolean",
-      "default": true
+      "default": 10
     }
   ]
 }

--- a/configs/queries/orgs/participants/organizations/params.json
+++ b/configs/queries/orgs/participants/organizations/params.json
@@ -36,6 +36,11 @@
       "name": "excludeBots",
       "type": "boolean",
       "default": true
+    },
+    {
+      "name": "excludeUnknown",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/participants/organizations/template.sql
+++ b/configs/queries/orgs/participants/organizations/template.sql
@@ -50,8 +50,9 @@ WHERE
                 AND ge2.number = ge.number
             )
         {% else %}
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
         {% if excludeBots %}
         -- Exclude bot users.
         AND ge.actor_login NOT LIKE '%bot%'

--- a/configs/queries/orgs/participants/roles/template.sql
+++ b/configs/queries/orgs/participants/roles/template.sql
@@ -100,6 +100,20 @@ WITH repos AS (
             {% when 'past_90_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 90 DAY)
             {% when 'past_12_months' %} AND created_at > (CURRENT_DATE() - INTERVAL 12 MONTH)
         {% endcase %}
+), commit_authors AS (
+    SELECT
+        COUNT(DISTINCT actor_login) AS commit_authors
+        FROM github_events ge
+    WHERE
+        repo_id IN (SELECT repo_id FROM repos)
+        AND ge.type ='PushEvent'
+        AND ge.action = ''
+        {% case period %}
+            {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 7 DAY)
+            {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 28 DAY)
+            {% when 'past_90_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 90 DAY)
+            {% when 'past_12_months' %} AND created_at > (CURRENT_DATE() - INTERVAL 12 MONTH)
+        {% endcase %}
 ), participants AS (
     SELECT
         COUNT(DISTINCT actor_login) AS participants
@@ -121,6 +135,7 @@ SELECT
     pr_commenters,
     issue_creators,
     issue_commenters,
+    commit_authors,
     participants
 FROM
     pr_creators,
@@ -128,6 +143,7 @@ FROM
     pr_commenters,
     issue_creators,
     issue_commenters,
+    commit_authors,
     participants
 
 

--- a/configs/queries/orgs/participants/trends/template.sql
+++ b/configs/queries/orgs/participants/trends/template.sql
@@ -69,8 +69,9 @@ WITH RECURSIVE seq(idx, current_period_day, past_period_day) AS (
             github_events ge
         WHERE
             repo_id IN (SELECT repo_id FROM repos)
-            AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-            AND ge.action IN ('opened', 'created', '')
+            -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+            AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+            AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
             {% case period %}
                 {% when 'past_7_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 14 DAY)
                 {% when 'past_28_days' %} AND created_at > (CURRENT_DATE() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/pull-requests/open-to-close-duration/medium/params.json
+++ b/configs/queries/orgs/pull-requests/open-to-close-duration/medium/params.json
@@ -24,7 +24,7 @@
     {
       "name": "excludeBots",
       "type": "boolean",
-      "default": true
+      "default": false
     }
   ]
 }

--- a/configs/queries/orgs/pull-requests/open-to-close-duration/top-repos/params.json
+++ b/configs/queries/orgs/pull-requests/open-to-close-duration/top-repos/params.json
@@ -24,7 +24,7 @@
     {
       "name": "excludeBots",
       "type": "boolean",
-      "default": true
+      "default": false
     }
   ]
 }

--- a/configs/queries/orgs/repos/active/ranking/template.sql
+++ b/configs/queries/orgs/repos/active/ranking/template.sql
@@ -7,15 +7,16 @@ WITH repos AS (
         {% if repoIds.size > 0 %}
         AND gr.repo_id IN ({{ repoIds | join: ',' }})
         {% endif %}
-), repos_with_stars AS (
+), repos_with_activities AS (
     SELECT
         repo_id,
-        COUNT(*) AS stars
+        COUNT(*) AS activities
     FROM github_events ge
     WHERE
         ge.repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 28 DAY)

--- a/configs/queries/orgs/repos/active/total/template.sql
+++ b/configs/queries/orgs/repos/active/total/template.sql
@@ -19,8 +19,9 @@ WITH repos AS (
     FROM github_events ge
     WHERE
         ge.repo_id IN (SELECT repo_id FROM repos)
-        AND ge.type IN ('PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent', 'IssueCommentEvent', 'PushEvent')
-        AND ge.action IN ('opened', 'created', '')
+        -- Events considered as participation (Exclude `WatchEvent`, which means star a repo).
+        AND ge.type IN ('IssueCommentEvent',  'DeleteEvent',  'CommitCommentEvent',  'MemberEvent',  'PushEvent',  'PublicEvent',  'ForkEvent',  'ReleaseEvent',  'PullRequestReviewEvent',  'CreateEvent',  'GollumEvent',  'PullRequestEvent',  'IssuesEvent',  'PullRequestReviewCommentEvent')
+        AND ge.action IN ('added', 'published', 'reopened', 'closed', 'created', 'opened', '')
         {% case period %}
             {% when 'past_7_days' %} AND created_at > (NOW() - INTERVAL 14 DAY)
             {% when 'past_28_days' %} AND created_at > (NOW() - INTERVAL 56 DAY)

--- a/configs/queries/orgs/stars/locations/filled-ratio/params.json
+++ b/configs/queries/orgs/stars/locations/filled-ratio/params.json
@@ -24,13 +24,7 @@
     {
       "name": "n",
       "type": "integer",
-      "enums": [10, 20, 30, 40, 50],
       "default": 10
-    },
-    {
-      "name": "excludeBots",
-      "type": "boolean",
-      "default": false
     }
   ]
 }

--- a/configs/queries/orgs/stars/locations/filled-ratio/template.sql
+++ b/configs/queries/orgs/stars/locations/filled-ratio/template.sql
@@ -7,39 +7,24 @@ WITH repos AS (
         {% if repoIds.size > 0 %}
         AND gr.repo_id IN ({{ repoIds | join: ',' }})
         {% endif %}
-), stars_per_country AS (
+), stars_overview AS (
     SELECT
-        IF(gu.country_code IN ('', 'N/A', 'UND'), 'UND', gu.country_code) AS country_code,
-        COUNT(*) AS stars
+        SUM(CASE WHEN gu.country_code NOT IN ('', 'N/A', 'UND') THEN 1 ELSE 0 END) AS stars_with_country_code,
+        COUNT(*) AS stars_total
     FROM github_events ge
     JOIN github_users gu ON ge.actor_login = gu.login
     WHERE
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'WatchEvent'
         AND ge.action = 'started'
-        {% if excludeBots %}
-        -- Exclude bot users.
-        AND ge.actor_login NOT LIKE '%bot%'
-        {% endif %}
-        {% if excludeUnknown %}
-        -- Exclude users with no country code.
-        AND gu.country_code NOT IN ('', 'N/A', 'UND')
-        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)
             {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 90 DAY)
             {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
         {% endcase %}
-    GROUP BY gu.country_code
-), stars_total AS (
-    SELECT SUM(stars) AS stars_total FROM stars_per_country
 )
 SELECT
-    country_code,
-    stars,
-    ROUND(stars / st.stars_total * 100, 2) AS percentage
+    ROUND(so.stars_with_country_code / so.stars_total * 100, 2) AS percentage
 FROM
-    stars_per_country spc,
-    stars_total st
-LIMIT {{ n }}
+    stars_overview so

--- a/configs/queries/orgs/stars/locations/params.json
+++ b/configs/queries/orgs/stars/locations/params.json
@@ -30,6 +30,11 @@
       "name": "excludeBots",
       "type": "boolean",
       "default": true
+    },
+    {
+      "name": "excludeUnknown",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/stars/locations/template.sql
+++ b/configs/queries/orgs/stars/locations/template.sql
@@ -17,14 +17,17 @@ WITH repos AS (
         ge.repo_id IN (SELECT repo_id FROM repos)
         AND ge.type = 'WatchEvent'
         AND ge.action = 'started'
+
         {% if excludeBots %}
         -- Exclude bot users.
         AND ge.actor_login NOT LIKE '%bot%'
         {% endif %}
+
         {% if excludeUnknown %}
         -- Exclude users with no country code.
         AND gu.country_code NOT IN ('', 'N/A', 'UND')
         {% endif %}
+
         {% case period %}
             {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)
@@ -36,10 +39,11 @@ WITH repos AS (
     SELECT SUM(stars) AS stars_total FROM stars_per_country
 )
 SELECT
-    country_code,
-    stars,
-    ROUND(stars / st.stars_total * 100, 2) AS percentage
+    spc.country_code,
+    spc.stars,
+    ROUND(spc.stars / st.stars_total * 100, 2) AS percentage
 FROM
     stars_per_country spc,
     stars_total st
+ORDER BY spc.stars DESC
 LIMIT {{ n }}

--- a/configs/queries/orgs/stars/organizations/filled-ratio/params.json
+++ b/configs/queries/orgs/stars/organizations/filled-ratio/params.json
@@ -24,13 +24,12 @@
     {
       "name": "n",
       "type": "integer",
-      "enums": [10, 20, 30, 40, 50],
       "default": 10
     },
     {
       "name": "excludeBots",
       "type": "boolean",
-      "default": false
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/stars/organizations/filled-ratio/template.sql
+++ b/configs/queries/orgs/stars/organizations/filled-ratio/template.sql
@@ -7,10 +7,16 @@ WITH repos AS (
         {% if repoIds.size > 0 %}
         AND gr.repo_id IN ({{ repoIds | join: ',' }})
         {% endif %}
-), stars_per_country AS (
+), stars_overview AS (
     SELECT
-        IF(gu.country_code IN ('', 'N/A', 'UND'), 'UND', gu.country_code) AS country_code,
-        COUNT(*) AS stars
+        SUM(CASE
+            WHEN
+                gu.organization NOT IN ('', '-', 'none', 'no', 'home', 'n/a', 'null', 'unknown')
+                AND LENGTH(gu.organization) != 0
+            THEN 1
+            ELSE 0
+        END) AS stars_with_org,
+        COUNT(*) AS stars_total
     FROM github_events ge
     JOIN github_users gu ON ge.actor_login = gu.login
     WHERE
@@ -21,25 +27,14 @@ WITH repos AS (
         -- Exclude bot users.
         AND ge.actor_login NOT LIKE '%bot%'
         {% endif %}
-        {% if excludeUnknown %}
-        -- Exclude users with no country code.
-        AND gu.country_code NOT IN ('', 'N/A', 'UND')
-        {% endif %}
         {% case period %}
             {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
             {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)
             {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 90 DAY)
             {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
         {% endcase %}
-    GROUP BY gu.country_code
-), stars_total AS (
-    SELECT SUM(stars) AS stars_total FROM stars_per_country
 )
 SELECT
-    country_code,
-    stars,
-    ROUND(stars / st.stars_total * 100, 2) AS percentage
+    ROUND(so.stars_with_org / so.stars_total * 100, 2) AS percentage
 FROM
-    stars_per_country spc,
-    stars_total st
-LIMIT {{ n }}
+    stars_overview so

--- a/configs/queries/orgs/stars/organizations/params.json
+++ b/configs/queries/orgs/stars/organizations/params.json
@@ -30,6 +30,11 @@
       "name": "excludeBots",
       "type": "boolean",
       "default": true
+    },
+    {
+      "name": "excludeUnknown",
+      "type": "boolean",
+      "default": true
     }
   ]
 }

--- a/configs/queries/orgs/stars/organizations/template.sql
+++ b/configs/queries/orgs/stars/organizations/template.sql
@@ -7,35 +7,48 @@ WITH repos AS (
         {% if repoIds.size > 0 %}
         AND gr.repo_id IN ({{ repoIds | join: ',' }})
         {% endif %}
+), stars_per_org AS (
+    SELECT
+        IF(
+            gu.organization NOT IN ('', '-', 'none', 'no', 'home', 'n/a', 'null', 'unknown') AND LENGTH(gu.organization) != 0,
+            TRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(gu.organization, ',', ''), '-', ''), '@', ''), 'www.', ''), 'inc', ''), '.com', ''), '.cn', ''), '.', '')),
+            'Unknown'
+        ) AS organization_name,
+        COUNT(DISTINCT actor_login) AS stars
+    FROM github_events ge
+    JOIN github_users gu ON ge.actor_login = gu.login
+    WHERE
+        ge.repo_id IN (SELECT repo_id FROM repos)
+        AND ge.type = 'WatchEvent'
+        AND ge.action = 'started'
+
+        {% if excludeBots %}
+        -- Exclude bot users.
+        AND ge.actor_login NOT LIKE '%bot%'
+        {% endif %}
+
+        {% if excludeUnknown %}
+        -- Exclude users with no organization.
+        AND LENGTH(gu.organization) != 0
+        AND gu.organization NOT IN ('', '-', 'none', 'no', 'home', 'n/a', 'null', 'unknown')
+        {% endif %}
+
+        {% case period %}
+            {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
+            {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)
+            {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 90 DAY)
+            {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
+        {% endcase %}
+    GROUP BY organization_name
+), stars_total AS (
+    SELECT SUM(stars) AS stars_total FROM stars_per_org
 )
 SELECT
-    IF(
-        gu.organization NOT IN ('', '-', 'none', 'no', 'home', 'n/a', 'null', 'unknown') AND LENGTH(gu.organization) != 0,
-        TRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(gu.organization, ',', ''), '-', ''), '@', ''), 'www.', ''), 'inc', ''), '.com', ''), '.cn', ''), '.', '')),
-        'Unknown'
-    ) AS organization_name,
-    COUNT(DISTINCT actor_login) AS stars
-FROM github_events ge
-JOIN github_users gu ON ge.actor_login = gu.login
-WHERE
-    ge.repo_id IN (SELECT repo_id FROM repos)
-    AND ge.type = 'WatchEvent'
-    AND ge.action = 'started'
-    {% if excludeBots %}
-    -- Exclude bot users.
-    AND ge.actor_login NOT LIKE '%bot%'
-    {% endif %}
-    {% if excludeUnknown %}
-    -- Exclude users with no organization.
-    AND LENGTH(gu.organization) != 0
-    AND gu.organization NOT IN ('', '-', 'none', 'no', 'home', 'n/a', 'null', 'unknown')
-    {% endif %}
-    {% case period %}
-        {% when 'past_7_days' %} AND ge.created_at > (NOW() - INTERVAL 7 DAY)
-        {% when 'past_28_days' %} AND ge.created_at > (NOW() - INTERVAL 28 DAY)
-        {% when 'past_90_days' %} AND ge.created_at > (NOW() - INTERVAL 90 DAY)
-        {% when 'past_12_months' %} AND ge.created_at > (NOW() - INTERVAL 12 MONTH)
-    {% endcase %}
-GROUP BY organization_name
-ORDER BY stars DESC
+    spo.organization_name,
+    spo.spostars,
+    ROUND(spo.stars / st.stars_total * 100, 2) AS percentage
+FROM
+    stars_per_org spo,
+    stars_total st
+ORDER BY spc.stars DESC
 LIMIT {{ n }}


### PR DESCRIPTION
- [ ] 1. Consider all events (excluded stars event) as activities of participant

- [ ] 2. Refactor the result of reviewed-ratio and issues closed-ratio, align with pr merged-ratio

 
   <details>
   <summary>Sample response</summary>

    **issues closed-ratio:**
    
    ```json
    [
          {
              "current_period_issues": 226,
              "current_period_percentage": 46.89,
              "past_period_issues": 171,
              "past_period_percentage": 49.57,
              "percentage_change": -2.68,
              "type": "un-closed"
          },
          {
              "current_period_issues": 216,
              "current_period_percentage": 44.81,
              "past_period_issues": 148,
              "past_period_percentage": 42.9,
              "percentage_change": 1.91,
              "type": "others-closed"
          },
          {
              "current_period_issues": 40,
              "current_period_percentage": 8.3,
              "past_period_issues": 26,
              "past_period_percentage": 7.54,
              "percentage_change": 0.76,
              "type": "self-closed"
          }
    ]
    ```
    
    **pr merged-ratio:**
    
    ```json
    [
          {
              "type": "reviewed",
              "current_period_prs": 685,
              "current_period_percentage": 83.13,
              "past_period_prs": 544,
              "past_period_percentage": 77.94,
              "percentage_change": 5.19
          },
          {
              "type": "un-reviewed",
              "current_period_prs": 139,
              "current_period_percentage": 16.87,
              "past_period_prs": 154,
              "past_period_percentage": 22.06,
              "percentage_change": -5.19
          }
    ]
    ```

    </details>

- [ ] 3. add `percentage` column for stars and participants's counrty / organization queries

- [ ] 4. add `excludeUnknown` option  for stars and participants's counrty / organization queries

- [ ] 5. add `filled-ratio` queries for counrty / organization queries, filled-ratio indicate that the proportion of users who have filled out the country/organization information

    - [/orgs/stars/organizations/filled-ratio?ownerId=11855343](https://github.com/pingcap/ossinsight/pull/1617/files#diff-38cc35c9dede88422eacb07eddd3a5eff8918c905135c15e1e38d2bb16b8ea9d)
    - [/orgs/stars/locations//filled-ratio?ownerId=11855343](https://github.com/pingcap/ossinsight/pull/1617/files#diff-021261db682bd13c2c2623c504e49dfe3284724fc156dedade40ef98f491b0a2)
    - [/orgs/participants/organizations/filled-ratio](https://github.com/pingcap/ossinsight/pull/1617/commits/8c5b32ddcf8f284bb573e095aaf712cb5af85980#diff-5f56ca3a62d99f5de26360428f8e7fc154ddd2655312bffd4084fedaf2bc32bb)
    - [/orgs/participants/locations/filled-ratio](https://github.com/pingcap/ossinsight/pull/1617/commits/8c5b32ddcf8f284bb573e095aaf712cb5af85980#diff-9ce75e27395f7cb70a47ee07f4ed1519cd10be9a428108c7993801bf30e3414b)

- [ ] 6. add `commit_authors` column for query `/orgs/participants/roles`

- [ ] 7. set the option `excludeBots` to `false` for queries:

  - `/orgs/issues/open-to-close-duration/total`
  - `/orgs/issues/open-to-close-duration/top-repos`
  - `/orgs/pull_requests/open-to-close-duration/total`
  - `/orgs/pull_requests/open-to-close-duration/top-repos`

- [ ] fix wrong query [`/orgs/repos/active/ranking`](https://github.com/pingcap/ossinsight/pull/1617/files#diff-af9eeeff7c5f3269ed0086ef6c796f52e9fbac17e0f6df7e34a44be5f8e94e20)