### PR TITLE
config: Add ambientrun/ambient to open source game engines collection

### DIFF
--- a/etl/meta/collections/10013.game-engine.yml
+++ b/etl/meta/collections/10013.game-engine.yml
@@ -63,3 +63,4 @@ items:
   - jhasse/jngl
   - pinguin999/ALPACA
   - g3n/engine
+  - ambientrun/ambient


### PR DESCRIPTION
Add [Ambient](https://github.com/ambientrun/ambient) to the open source game engines collection