### PR TITLE
config: add isadorasophia/murder to game-engine collection

### DIFF
--- a/etl/meta/collections/10013.game-engine.yml
+++ b/etl/meta/collections/10013.game-engine.yml
@@ -64,3 +64,4 @@ items:
   - pinguin999/ALPACA
   - g3n/engine
   - ambientrun/ambient
+  - isadorasophia/murder


### PR DESCRIPTION
**What problem does this PR solve?**
Add isadorasophia/murder as part of the "game engines" list.