### PR TITLE
config: added HaxeFlixel to list of game engines

### DIFF
--- a/etl/meta/collections/10013.game-engine.yml
+++ b/etl/meta/collections/10013.game-engine.yml
@@ -49,6 +49,7 @@ items:
   - hajimehoshi/ebiten
   - hexops/mach
   - HaxeFoundation/haxe
+  - HaxeFlixel/flixel
   - Esenthel/EsenthelEngine
   - aws/lumberyard
   - FlaxEngine/FlaxEngine


### PR DESCRIPTION
Added HaxeFlixel

**What problem does this PR solve?**

HaxeFlixel is a popular 2D OSS game engine with over 1.8K stars, and seems like it should be on the list:
https://github.com/HaxeFlixel/flixel
