### PR TITLE
config: Fix ambientrun/ambient case

### DIFF
--- a/etl/meta/collections/10013.game-engine.yml
+++ b/etl/meta/collections/10013.game-engine.yml
@@ -64,7 +64,7 @@ items:
   - jhasse/jngl
   - pinguin999/ALPACA
   - g3n/engine
-  - ambientrun/ambient
+  - AmbientRun/Ambient
   - isadorasophia/murder
   - axmolengine/axmol
   - castle-engine/castle-engine


### PR DESCRIPTION
**What problem does this PR solve?**

It seems like Ambient is still not showing up in the game engine list, so figured it might be case sensitive.