### PR TITLE
data-explorer: introduce error handling for long questions

### DIFF
--- a/packages/api-server/src/plugins/services/explorer-service/index.ts
+++ b/packages/api-server/src/plugins/services/explorer-service/index.ts
@@ -127,7 +127,10 @@ export class ExplorerService {
         const logger = this.logger.child({ questionId: questionId });
         const normalizedQuestion = this.normalizeQuestion(q);
         if (normalizedQuestion.length > 512) {
-            throw new APIError(400, 'The question is too long, please shorten it.');
+            const message = `The question is too long, please shorten it.`;
+            throw new ExplorerPrepareQuestionError(message, QuestionFeedbackType.ErrorQuestionIsTooLong, {
+                message: message
+            });
         }
 
         // Prepare the new question.

--- a/packages/api-server/src/plugins/services/explorer-service/types.ts
+++ b/packages/api-server/src/plugins/services/explorer-service/types.ts
@@ -108,4 +108,5 @@ export enum QuestionFeedbackType {
   ErrorEmptyResult = "error-empty-result",
   ErrorSummaryGenerate = "error-summary-generate",
   ErrorUnknown = "error-unknown",
+  ErrorQuestionIsTooLong = "error-question-too-long",
 }

--- a/web/src/api/explorer.ts
+++ b/web/src/api/explorer.ts
@@ -99,6 +99,7 @@ export enum QuestionErrorType {
   EMPTY_RESULT = 'error-empty-result',
   SUMMARY_GENERATE = 'error-summary-generate',
   UNKNOWN = 'error-unknown',
+  QUESTION_IS_TOO_LONG = 'error-question-too-long',
 }
 
 export interface PlanStep {

--- a/web/src/pages/explore/_components/SqlSection/ErrorMessage.tsx
+++ b/web/src/pages/explore/_components/SqlSection/ErrorMessage.tsx
@@ -30,6 +30,8 @@ export default function ErrorMessage ({ error }: { error: unknown }) {
       return <Typography variant="body1">Failed to generate SQL. Optimize your question for effective SQL, or get ideas from <Link to='/explore/'>popular questions</Link>.</Typography>;
     case QuestionErrorType.SQL_CAN_NOT_ANSWER:
       return <Typography variant="body1">Sorry, I can&apos;t generate SQL as your question is not GitHub-related or beyond our data source.</Typography>;
+    case QuestionErrorType.QUESTION_IS_TOO_LONG:
+      return <Typography variant="body1">Sorry, your question is too long. Please simplify it to a few sentences.</Typography>;
     case QuestionErrorType.VALIDATE_SQL: {
       const errorDetails = getErrorDetails(QuestionErrorType.VALIDATE_SQL, question.error);
       if (notNullish(errorDetails)) {


### PR DESCRIPTION
<!--

Thank you for contributing to OSS Insight!

PR Title Format:

Please add the scope of pull request as the title prefix like:

```
<scope>: what's changed.
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add pingcap/tidb repo to open source database collection
```
-->

**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #1530

Problem Summary:

**What is changed and how it works?**

In this PR, we address the need for more robust error handling within the `Data-explorer` module. Users will now receive an informative error message if their query exceeds the defined length.
