### PR TITLE
config: create 10088.webrtc.yml

### DIFF
--- a/etl/meta/collections/10088.webrtc.yml
+++ b/etl/meta/collections/10088.webrtc.yml
@@ -1,0 +1,20 @@
+id: 10088
+name: WebRTC
+items:
+  - livekit/livekit
+  - jitsi/jitsi-meet
+  - vector-im/element-call
+  - meetecho/janus-gateway
+  - versatica/mediasoup
+  - medooze/media-server
+  - pion/webrtc
+  - webrtc-rs/webrtc
+  - paullouisageneau/libdatachannel
+  - murat-dogan/node-datachannel
+  - lerouxrgd/datachannel-rs
+  - aiortc/aiortc
+  - sipsorcery-org/sipsorcery
+  - shinyoshiaki/werift-webrtc
+  - react-native-webrtc/react-native-webrtc
+  - flutter-webrtc/flutter-webrtc
+  


### PR DESCRIPTION
Create collection for WebRTC projects ranging from full stack solutions, to media servers, and WebRTC libraries. WebRTC is a niche area so I preferred adding these projects into a single collection rather than breaking them up into separate collections.

This collection is numbered 10088 since there is a pending PR for new collection 10087.