### PR TITLE
config: Added 10089.relational-database.yml

### DIFF
--- a/etl/meta/collections/2.open-source-database.yml
+++ b/etl/meta/collections/2.open-source-database.yml
@@ -2,18 +2,40 @@ id: 2
 name: Open Source Database
 items:
   - elastic/elasticsearch
+  - pingcap/tidb
+  - cockroachdb/cockroach
+  - clickhouse/clickhouse
   - mongodb/mongo
+  - vitessio/vitess
   - apache/druid
   - tikv/tikv
   - apple/foundationdb
+  - yugabyte/yugabyte-db
+  - citusdata/citus
+  - greenplum-db/gpdb
   - trinodb/trino
   - apache/hbase
+  - MariaDB/server
   - apache/hive
   - apache/ignite
+  - apache/incubator-doris
+  - apache/kylin
+  - StarRocks/starrocks
+  - percona/percona-server
+  - oceanbase/oceanbase
   - datafuselabs/databend
   - taosdata/TDengine
+  - risinglightdb/risinglight
+  - ApsaraDB/galaxysql
+  - ApsaraDB/galaxyengine
+  - singularity-data/risingwave
+  - prestodb/presto
   - FerretDB/FerretDB
   - CeresDB/ceresdb
+  - postgres/postgres
+  - duckdb/duckdb
+  - apache/shardingsphere
   - milvus-io/milvus
   - CUBRID/cubrid
   - GreptimeTeam/greptimedb
+  - cloudberrydb/cloudberrydb


### PR DESCRIPTION
This PR intends to add a separate collection for relational databases as per the discussion in #1693 and updates the Open Source Database collection to include the non-relational databases.
Some query engines that do not directly store data but query relational DBs have been added to the relational databases section.
