### PR TITLE
add dlt-hub/dlt into modern data stack ingestion list

### DIFF
--- a/etl/meta/collections/10044.modern-data-stack.yml
+++ b/etl/meta/collections/10044.modern-data-stack.yml
@@ -47,6 +47,7 @@ items:
   - datahub-project/datahub
 
   # Data integration
+  - dlt-hub/dlt
   - airbytehq/airbyte
   - rudderlabs/rudder-server
   - jitsucom/jitsu


### PR DESCRIPTION
PR Title: config: add dlt-hub/dlt into modern data stack ingestion list

What problem does this PR solve?

Problem Summary:

The current ingestion list lacks the inclusion of DLT, a tool widely recognized for its flexibility and efficiency in data loading and transformation. This omission limits the scope of data sources OSS Insight can handle, potentially hindering the platform's ability to provide comprehensive insights.

What is changed and how it works?

Changes: This PR adds DLT to the modern data stack list in the OSS Insight configuration, ensuring it's recognized as a supported tool for data ingestion. 

