### PR TITLE
config: add langfuse to llm-tools collection

### DIFF
--- a/etl/meta/collections/10076.llm-tools.yml
+++ b/etl/meta/collections/10076.llm-tools.yml
@@ -20,3 +20,4 @@ items:
   - sobelio/llm-chain
   - Chainlit/chainlit
   - FlowiseAI/Flowise
+  - langfuse/langfuse


### PR DESCRIPTION
adds langfuse repo to llm-tools collection config.
langfuse: https://github.com/langfuse/langfuse/

langfuse is a an open source LLM engineering platform, providing observability, prompt management, evals, metrics & playground. it integrates with langchain, llama-index, open ai -- 3k github stars