### PR TITLE
config: add loft-sh/vcluster repo to kubernetes tooling collection

### DIFF
--- a/etl/meta/collections/10063.kubernetes-tooling.yml
+++ b/etl/meta/collections/10063.kubernetes-tooling.yml
@@ -32,3 +32,5 @@ items:
   - gimlet-io/gimlet
   - berops/claudie
   - gimlet-io/capacitor
+  - loft-sh/vcluster
+  


### PR DESCRIPTION
config: add loft-sh/vcluster repo to kubernetes tooling collection

Link: https://github.com/loft-sh/vcluster/
