### PR TITLE
config: Add Cubzh to game engine collection

### DIFF
--- a/etl/meta/collections/10013.game-engine.yml
+++ b/etl/meta/collections/10013.game-engine.yml
@@ -68,3 +68,4 @@ items:
   - isadorasophia/murder
   - axmolengine/axmol
   - castle-engine/castle-engine
+  - cubzh/cubzh


### PR DESCRIPTION
Adding [Cubzh](https://github.com/cubzh/cubzh) to the list of game engines. 🙂