### PR TITLE
Add zango to web framework collection

### DIFF
--- a/etl/meta/collections/10004.web-framework.yml
+++ b/etl/meta/collections/10004.web-framework.yml
@@ -62,3 +62,4 @@ items:
   - unjs/nitro
   - payloadcms/payload
   - tiangolo/fastapi
+  - healthlane-technologies/zango


### PR DESCRIPTION
**What problem does this PR solve?**

This PR adds the open source framework [Zango](https://zango.dev/) to the web framework collection.