### PR TITLE
config: add automq to 10032.message-and-streaming.yml & 10044.modern-da…

### DIFF
--- a/etl/meta/collections/10032.message-and-streaming.yml
+++ b/etl/meta/collections/10032.message-and-streaming.yml
@@ -16,4 +16,5 @@ items:
   - vernemq/vernemq
   - apache/flink
   - bloomberg/blazingmq
+  - automq/automq
   

--- a/etl/meta/collections/10044.modern-data-stack.yml
+++ b/etl/meta/collections/10044.modern-data-stack.yml
@@ -34,6 +34,7 @@ items:
   - apache/flink
   - apache/beam
   - redpanda-data/redpanda
+  - automq/automq
 
   # Stream Processing
   - bytewax/bytewax


### PR DESCRIPTION
## config: add automq/automq repo to message-and-streaming & modern-data-stack

AutoMQ is a cloud-first alternative to Kafka by decoupling durability to S3 and EBS. 10x cost-effective. Autoscale in seconds. Single-digit ms latency.

Recently, AutoMQ[1] has gained a lot of love and attention from the developer community, with the number of stars soon reaching 3000. It has also appeared on GitHub trending, both in the overall[2] and Java categories[3]. We hope to be featured on the OSSInsight list to be discovered by more developers.

[1]. https://github.com/AutoMQ/automq
[2]. https://github.motakasoft.com/trending/?d=2024-07-28&l=java
[3]. https://github.motakasoft.com/trending/?d=2024-07-27&l=all


