### PR TITLE
config: add project management collection (10096)

### DIFF
--- a/configs/collections/10096.project-management.yml
+++ b/configs/collections/10096.project-management.yml
@@ -1,0 +1,13 @@
+id: 10096
+name: Project Management
+items:
+  - AppFlowy-IO/AppFlowy
+  - makeplane/plane
+  - mattermost-community/focalboard
+  - frappe/erpnext
+  - hcengineering/platform
+  - opf/openproject
+  - kanboard/kanboard
+  - kuaifan/dootask
+  - Leantime/leantime
+  - JordanKnott/taskcafe


### PR DESCRIPTION
Add project management collection (10096), repos included:

  - AppFlowy-IO/AppFlowy
  - makeplane/plane
  - mattermost-community/focalboard
  - frappe/erpnext
  - hcengineering/platform
  - opf/openproject
  - kanboard/kanboard
  - kuaifan/dootask
  - Leantime/leantime
  - JordanKnott/taskcafe
