### PR TITLE
config: add hcengineering/platform to slack alternative collection

### DIFF
--- a/configs/collections/10061.slack-alternative.yml
+++ b/configs/collections/10061.slack-alternative.yml
@@ -12,3 +12,4 @@ items:
   - matrix-org/synapse
   - spacebarchat/spacebarchat
   - Linen-dev/linen.dev
+  - hcengineering/platform


### PR DESCRIPTION
Add hcengineering/platform (Huly Platform) to Slack Alternative collection.

More info about project here: https://huly.io
Repo: https://github.com/hcengineering/platform
