### PR TITLE
config: add kinsondigital/velaptor repo to game engine collection

### DIFF
--- a/configs/collections/10013.game-engine.yml
+++ b/configs/collections/10013.game-engine.yml
@@ -70,3 +70,4 @@ items:
   - castle-engine/castle-engine
   - flame-engine/flame
   - cubzh/cubzh
+  - KinsonDigital/Velaptor


### PR DESCRIPTION
**What problem does this PR solve?**

Adds a new game engine/framework to the game engine collection.