### PR TITLE
config: Add three.js to OSS Game Engines

### DIFF
--- a/configs/collections/10013.game-engine.yml
+++ b/configs/collections/10013.game-engine.yml
@@ -71,3 +71,4 @@ items:
   - flame-engine/flame
   - cubzh/cubzh
   - KinsonDigital/Velaptor
+  - mrdoob/three.js


### PR DESCRIPTION
If raylib and the other WebGL and graphics library abstractions count, then three.js certainly counts!

It’s easily the most popular game engine (and 3D abstraction) on the web. 😄