### PR TITLE
config: Add tyzo repo to headless CMS collection

### DIFF
--- a/configs/collections/10012.headless-cms.yml
+++ b/configs/collections/10012.headless-cms.yml
@@ -28,3 +28,4 @@ items:
   - superdesk/superdesk
   - TryGhost/Ghost
   - gentics/mesh
+  - tyzo-io/tyzo


### PR DESCRIPTION
Adding tyzo to the headless CMS collection