### PR TITLE
config: add keploy/keploy repo to api tools for developers collection

### DIFF
--- a/configs/collections/10040.api-tool-for-developer.yml
+++ b/configs/collections/10040.api-tool-for-developer.yml
@@ -16,3 +16,4 @@ items:
   - graphql-editor/graphql-editor
   - apioo/fusio
   - requestly/requestly
+  - keploy/keploy


### PR DESCRIPTION
<!--

Thank you for contributing to OSS Insight!

PR Title Format: config: add keploy/keploy repo to API tool for developers collection


Please add the scope of pull request as the title prefix like: 

```
<scope>: what's changed.
```

```
web: add keploy/keploy repo to API tool for developers collection
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add keploy/keploy repo to API tool for developers collection
```
-->

**What problem does this PR solve?**
Adds keploy's repository to https://ossinsight.io/collections/api-tool-for-developer/

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #1830 


Problem Summary:
Added Keploy's repository ( ) to the api tools for developers collection at https://ossinsight.io/collections/api-tool-for-developer/

**What is changed and how it works?**
Changed the following file to add keploy to the collection: https://github.com/pingcap/ossinsight/blob/main/configs/collections/10040.api-tool-for-developer.yml 