### PR TITLE
config: Add 10098 coding agent collection

### DIFF
--- a/configs/collections/10098.coding-agent.yml
+++ b/configs/collections/10098.coding-agent.yml
@@ -1,0 +1,14 @@
+id: 10097
+name: AI Training Observability
+items:
+  - anthropics/claude-code
+  - openai/codex
+  - Aider-AI/aider
+  - block/goose
+  - antinomyhq/forge
+  - plandex-ai/plandex  
+  - All-Hands-AI/OpenHands
+  - AutoCodeRoverSG/auto-code-rover
+  - sourcegraph/cody
+  - qodo-ai/pr-agent
+  - vanna-ai/vanna


### PR DESCRIPTION
Add coding agent collectoin, include autonomous coding agents, AI pair programmers include: 

  - anthropics/claude-code
  - openai/codex
  - Aider-AI/aider
  - block/goose
  - antinomyhq/forge
  - plandex-ai/plandex  
  - All-Hands-AI/OpenHands
  - AutoCodeRoverSG/auto-code-rover
  - sourcegraph/cody
  - qodo-ai/pr-agent
  - vanna-ai/vanna