### PR TITLE
config: Add Kuzu to the graph database list

### DIFF
--- a/configs/collections/10008.graph-database.yml
+++ b/configs/collections/10008.graph-database.yml
@@ -17,3 +17,4 @@ items:
   - surrealdb/surrealdb
   - apache/age
   - FalkorDB/FalkorDB
+  - kuzudb/kuzu


### PR DESCRIPTION
[Kuzu](https://github.com/kuzudb/kuzu) is an open source,  embedded graph database that's been gaining in popularity, and we have an active user community building production applications. We'd much appreciate being included in this list as well. Thank you!

<!--

Thank you for contributing to OSS Insight!

PR Title Format:

Please add the scope of pull request as the title prefix like:

```
<scope>: what's changed.
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add pingcap/tidb repo to open source database collection
```
-->

**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Issue Number: close #1858 

Problem Summary:

Updated the last line in `10008.graph-database.yml` to point to the Kuzu GitHub repo.

If there's any other place where it needs to be updated to build the site, please let me know. Thanks!