### PR TITLE
feat: reduce motion hook to supress animation

### DIFF
--- a/web/src/components/RealtimeSummary/index.tsx
+++ b/web/src/components/RealtimeSummary/index.tsx
@@ -3,11 +3,13 @@ import { Axis, BarSeries, Dataset, Grid, Once } from '@djagger/echartsx';
 import { useLocation } from '@docusaurus/router';
 import React from 'react';
 import AnimatedNumber from 'react-awesome-animated-number';
+import { format } from 'date-fns';
 import useVisibility from '../../hooks/visibility';
 import { useTotalEvents } from '../RemoteCharts/hook';
 import { useRealtimeEvents } from './hooks';
 
 import { Box, Stack, styled, Tooltip, useMediaQuery } from '@mui/material';
+import { usePrefersReducedMotion } from '@site/src/hooks/motion';
 
 const Chart = ({ visible }: { visible: boolean }) => {
   const data = useRealtimeEvents(visible);
@@ -68,13 +70,25 @@ const Numbers = styled(Span)({
   lineHeight: 1.1,
 });
 
-const TooltipTitle = () => (
-  <div>
-    ⌛️ GitHub events data importing in <b>Realtime</b>.
-    <br/>
-    📊 Each bar = Data importing in per 5 seconds.
-  </div>
-);
+const TooltipTitle = () => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  if (prefersReducedMotion) {
+    return (
+      <div>
+        ⌛️ GitHub events data imported at {format(new Date(), "yyyy-MM-dd HH:mm:ss")}.
+        <br/>
+        📊 Each bar = Data imported in per 5 seconds.
+      </div>
+    );
+  }
+  return (
+    <div>
+      ⌛️ GitHub events data importing at <b>Realtime</b>.
+      <br/>
+      📊 Each bar = Data importing in per 5 seconds.
+    </div>
+  );
+};
 
 export const RealtimeSummary = () => {
   const visible = useVisibility();

--- a/web/src/components/milestone/MilestoneLite.tsx
+++ b/web/src/components/milestone/MilestoneLite.tsx
@@ -5,6 +5,7 @@ import { isNullish, notNullish } from '@site/src/utils/value';
 import { styled } from '@mui/material';
 import { Milestone } from '@ossinsight/api';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { usePrefersReducedMotion } from '@site/src/hooks/motion';
 
 interface MilestoneLiteProps {
   repoId?: number;
@@ -26,16 +27,21 @@ export function MilestoneLite ({ repoId, interval = 2500 }: MilestoneLiteProps) 
 
 const Milestones = ({ milestones, interval }: { milestones: Milestone[] | undefined, interval: number }) => {
   const [i, setI] = useState(0);
+  const prefersReducedMotion = usePrefersReducedMotion();  
 
   useEffect(() => {
     if (notNullish(milestones) && milestones.length > 0) {
-      const h = setInterval(() => {
-        setI(i => ((i + 1) % milestones.length));
-      }, interval);
+      if (prefersReducedMotion) {
+        setI(0);
+      } else {
+        const h = setInterval(() => {
+          setI(i => ((i + 1) % milestones.length));
+        }, interval);
 
-      return () => clearInterval(h);
+        return () => clearInterval(h);
+      }
     }
-  }, [milestones?.length, interval]);
+  }, [milestones?.length, interval, prefersReducedMotion]);
 
   const key = useMemo(() => {
     if (isNullish(milestones)) {

--- a/web/src/hooks/motion.ts
+++ b/web/src/hooks/motion.ts
@@ -1,0 +1,3 @@
+export function usePrefersReducedMotion () {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}


### PR DESCRIPTION
**What problem does this PR solve?**

Issue Number: close https://github.com/pingcap/ossinsight/issues/1880

Problem Summary:

There are 3 parts updated periodically with animation on upper part of UI which can make users distracted.

1. Total events number on header.
2. Graph on header.
3. Content in highlight on repository's analytics page.

**What is changed and how it works?**

This PR adds [prefers-reduce-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion) as a hook. When users enable the feature on their OS it makes the above-mentioned parts freezing and helps reading page undistracted.

When reducing motion is enabled,

* Total events number and graph don't update.
* Their description indicates that they are not a realtime data.
* Content in highlight doesn't update and latest one is shown.

<img width="634" height="187" alt="image" src="https://github.com/user-attachments/assets/3f66fc10-33cc-4c13-accf-9445b71d66ce" />

