### PR TITLE
Add Bruno to testing tools and API developer tools collection

### DIFF
--- a/configs/collections/10027.testing-tool.yml
+++ b/configs/collections/10027.testing-tool.yml
@@ -24,3 +24,4 @@ items:
   - nightwatchjs/nightwatch
   - getanteon/anteon
   - puppeteer/puppeteer
+  - usebruno/bruno

--- a/configs/collections/10040.api-tool-for-developer.yml
+++ b/configs/collections/10040.api-tool-for-developer.yml
@@ -17,3 +17,4 @@ items:
   - apioo/fusio
   - requestly/requestly
   - keploy/keploy
+  - usebruno/bruno


### PR DESCRIPTION
**What problem does this PR solve?**

Problem Summary: Bruno is a popular API testing tool with 40k+ GitHub stars and a growing developer community, but it was missing from the **API tools** and **testing tools** collections.

**What is changed and how it works?**

This PR adds Bruno to the relevant collections so it shows up correctly as an API testing and developer tool.