### PR TITLE
Add new agents to llm-tools configuration

### DIFF
--- a/configs/collections/10076.llm-tools.yml
+++ b/configs/collections/10076.llm-tools.yml
@@ -24,3 +24,5 @@ items:
   - langfuse/langfuse
   - keploy/keploy
   - VoltAgent/voltagent
+  - iflytek/astron-agent
+  - iflytek/astron-rpa


### PR DESCRIPTION
<!--

Thank you for contributing to OSS Insight!

PR Title Format:

Please add the scope of pull request as the title prefix like:

```
<scope>: what's changed.
```

The scope could be `config`, `api`, `web`, `blog` and etc.

Suppose you submit a new repository to the collection's configuration, your pull request title could be:

```
config: add pingcap/tidb repo to open source database collection
```
-->

**What problem does this PR solve?**

<!--

Please create an issue first to describe the problem.

It's best be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check <https://github.com/pingcap/ossinsight/issues>.

-->

Some popular AI tools from iFlytek are missing in the `llm-tools` collection.

Issue Number: close #1896

Problem Summary:

The current `llm-tools` collection is missing `iflytek/astron-agent` and `iflytek/astron-rpa`. Adding these repositories ensures the collection remains up-to-date and comprehensive for users interested in AI agent tools.

**What is changed and how it works?**

- Added `iflytek/astron-agent` to the `llm-tools` collection.
- Added `iflytek/astron-rpa` to the `llm-tools` collection.