### PR TITLE
Restore original README with feature descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,186 @@
-This repository now follows a monorepo layout inspired by [belgattitude/nextjs-monorepo-example](https://github.com/belgattitude/nextjs-monorepo-example) and [vercel/turborepo basic](https://github.com/vercel/turborepo/tree/main/examples/basic).
+<h1 align="center">Open Source Software Insight!</h1>
 
-## Structure
+<div align="center">
+<a href="https://ossinsight.io">
+  <img src="https://ossinsight.io/img/screenshots/homepage.gif"
+</a>
+</div>
 
-- `apps/web`: the Next.js application
-- `packages/typescript-config`: shared TypeScript presets
-- `turbo.json`: workspace task orchestration
+<h4 align="center">
+  <b><a href="https://ossinsight.io/explore/">Data Explorer</a></b>
+  •
+  <b><a href="https://ossinsight.io/collections/open-source-database">Repo Rankings</a></b>
+  •
+  <b><a href="https://ossinsight.io/analyze/Ovilia">Developer Analytics</a></b>
+  •
+  <a href="https://ossinsight.io/analyze/pingcap/tidb">Repo Analytics</a>
+  •
+  <a href="https://ossinsight.io/collections/open-source-database">Collections</a>
+  •
+  <a href="https://ossinsight.io/docs/workshop">Workshop</a>
+  •
+  <a href="https://ossinsight.io/blog">Blog</a>
+  •
+  <a href="https://ossinsight.io/docs">API</a>
+  •
+  <a href="https://twitter.com/OSSInsight">Twitter</a>
+</h3>
 
-## Getting Started
+## Introduction
 
-First, run the development server:
+OSS Insight is a powerful tool that provides comprehensive, valuable, and trending insights into the open source world by analyzing 10+ billion rows of GitHub events data.
+
+OSS Insight's <a href="https://ossinsight.io/explore/">Data Explorer</a> provides a new way to explore GitHub data. Simply ask your question in natural language and Data Explorer will generate SQL, query the data, and present the results visually.
+
+OSS Insight also provides in-depth analysis of individual GitHub repositories and developers, as well as the ability to compare two repositories using the same metrics.
+  
+[🎦 Video - OSS Insight: Easiest New Way to Analyze Open Source Software](https://www.youtube.com/watch?v=6ofDBgXh4So&t=1s)
+
+### **Feature 0: Shareable Insight Widgets**
+
+| Repository Activity Trends | Collaborative Productivity - Last 28 days |
+| ----------- | ----------- |
+|<img src="https://next.ossinsight.io/widgets/official/compose-activity-trends/thumbnail.png?repo_id=41986369&image_size=auto" />|<img src="https://next.ossinsight.io/widgets/official/compose-last-28-days-collaborative-productivity/thumbnail.png?repo_id=41986369&image_size=auto" />|
+
+| Repository Performance Stats - Last 28 days | Active Contributors - Last 28 days |
+| ----------- | ----------- |
+|<img src="https://next.ossinsight.io/widgets/official/compose-last-28-days-stats/thumbnail.png?repo_id=41986369&image_size=auto" />|<img src="https://next.ossinsight.io/widgets/official/compose-recent-active-contributors/thumbnail.png?repo_id=41986369&limit=100&image_size=auto"/>|
+
+| Star Geographic Distribution | Star History |
+| ----------- | ----------- |
+|<img src="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?activity=stars&repo_id=41986369&image_size=auto" />|<img src="https://next.ossinsight.io/widgets/official/analyze-repo-stars-history/thumbnail.png?repo_id=41986369&image_size=auto" />|
+
+For more charming widgets, please [Check it out 👉](https://next.ossinsight.io/widgets?utm_source=github&utm_medium=referral)
+
+### **Feature 1: GPT-Powered Data Exploration**
+  
+Data Explorer provides a new way to discover trends and insights into 5+ billion rows of GitHub data.
+
+Simply ask your question in natural language and Data Explorer will generate SQL, query the data, and present the results visually. It's built with <a href="https://tidbcloud.com/channel/?utm_source=ossinsight&utm_medium=community&utm_campaign=chat2query_202301&utm_content=github_readme">Chat2Query</a>, a GPT-powered SQL generator in TiDB Cloud. 
+
+Examples:
+
+* [Projects similar to @facebook/react](https://ossinsight.io/explore?id=ba186a53-b2ab-4cad-a46f-e2c36566cacd)
+* [The most interesting Web3 projects](https://ossinsight.io/explore?id=f829026d-491c-44e0-937a-287f97a3cba7)
+* [Where are @kubernetes/kubernetes contributors from?](https://ossinsight.io/explore?id=754a681e-913f-4333-b55d-dbd8598bd84d)
+* [More popular questions](https://ossinsight.io/explore/)
+
+[🎦 Video - Data Explorer: Discover insights in GitHub data with GPT-generated SQL](https://www.youtube.com/watch?v=rZZfgOJ-quI)
+
+### **Feature 2: Technical Fields Analytics 👁️**
+
+* **GitHub Collections Analysis**
+  
+  Find insights about the monthly or historical rankings and trends in technical fields with curated repository lists.
+
+<div align="center">
+  <a href="https://en.pingcap.com/tidb-cloud/?utm_source=ossinsight&utm_medium=referral">
+     <img src="https://ossinsight.io/img/screenshots/homepage-collection.png" alt="GitHub Collections Analytics" height="500" />
+  </a>
+</div>
+
+
+  **Examples**:
+  
+  * [Collection: Web Framework](https://ossinsight.io/collections/web-framework)
+  * [Collection: Artificial Intelligence](https://ossinsight.io/collections/artificial-intelligence)
+  * [Collection: Web3](https://ossinsight.io/collections/web3)
+  * [More](https://ossinsight.io/collections/open-source-database) ...
+
+  **Welcome to add collections**
+
+  👏 We welcome your contributions here! You can suggest a new collection by [opening an issue](https://github.com/pingcap/ossinsight/issues).
+
+* **Deep Insight into some popular fields of technology**
+  
+  Share with you many deep insights into some popular fields of technology, such as open source Databases, JavaScript Framework, Low-code Development Tools and so on.
+
+   **Examples**:
+  * [Deep Insight Into Open Source Databases](https://ossinsight.io/blog/deep-insight-into-open-source-databases)
+  * [JavaScript Framework Repos Landscape 2021](https://ossinsight.io/blog/deep-insight-into-js-framework-2021)
+  * [Web Framework Repos Landscape 2021](https://ossinsight.io/blog/deep-insight-into-web-framework-2021)
+  * [More](https://ossinsight.io/blog) ...
+  
+  We’ll also share the SQL commands that generate all these analytical results above each chart, so you can use them on your own on TiDB Cloud following this [10-minute tutorial](https://ossinsight.io/blog/try-it-yourself/).
+
+### **Feature 3: Developer Analytics**
+
+Insights about **developer productivity**, **work cadence**, and **collaboration** from developers' contribution behavior.
+
+* **Basic**:
+  * Stars, behavior, most used languages，and contribution trends
+  * Code (commits, pull requests, pull request size and code line changes), code reviews, and issues
+* **Advanced**:
+  * Contribution time distribution for all kind of contribution activities
+  * Monthly stats about contribution activities in all public repositories
+
+<div align="center">
+    <img src="https://ossinsight.io/img/screenshots/homepage-developer.png" alt="Developer Analytics" height="500" />
+</div>
+
+### **Feature 4: Repository Analytics**
+
+Insights about the **code update frequency & degree of popularity** from repositories' status.
+
+* **Basic**:
+  * Stars, forks, issues, commits, pull requests, contributors, programming languages, and lines of code modified
+  * Historical trends of these metrics
+  * Time cost of issues, pull requests
+* **Advanced**:
+  * Geographical distribution of stargazers, issue creators, and pull request creators
+  * Company distribution of stargazers, issue creators, and pull request creators
+
+<div align="center">
+    <img src="https://ossinsight.io/img/screenshots/homepage-repository.png" alt="Repository Analytics" height="500" />
+</div>
+
+**Examples**:
+
+* [React](https://ossinsight.io/analyze/facebook/react)
+* [TiDB](https://ossinsight.io/analyze/pingcap/tidb)
+* [web3.js](https://ossinsight.io/analyze/web3/web3.js)
+* [Ant Design](https://ossinsight.io/analyze/ant-design/ant-design)
+* [Chaos Mesh](https://ossinsight.io/analyze/chaos-mesh/chaos-mesh)
+
+### **Feature 5: Compare Projects 🔨**
+
+Compare two projects using the repo metrics mentioned in **Repository Analytics**.
+
+**Examples**:
+* [Compare Vue and React](https://ossinsight.io/analyze/vuejs/vue?vs=facebook/react)
+* [Compare CockroachDB and TiDB](https://ossinsight.io/analyze/pingcap/tidb?vs=cockroachdb/cockroach)
+* [Compare PyTorch and TensorFlow](https://ossinsight.io/analyze/pytorch/pytorch?vs=tensorflow/tensorflow)
+  
+## Contribution
+
+We've released OSS Insight because it can do more insights about GitHub. We hope that others can benefit from the project. We are thankful for any contributions from the community.
+
+* [GitHub Discussions](https://github.com/pingcap/ossinsight/discussions): help with building, discussion about best practices.
+* [GitHub Issues](https://github.com/pingcap/ossinsight/issues): bugs, feature requests, and collection suggestions.
+* [GitHub PRs](https://github.com/pingcap/ossinsight/pulls): pull requests for features, fixes, and blog posts.
+
+## Contact
+
+We have a few channels for contact:
+
+* [GitHub Discussions](https://github.com/pingcap/ossinsight/discussions): You can ask a question or discuss here.
+* [@OSS Insight](https://twitter.com/OSSInsight) on Twitter
+* [TiDB Community](https://ask.pingcap.com/): This is the place to discuss anything related to TiDB.
+* [mail](mailto:ossinsight@pingcap.com):If you want to analyze more, please [contact us](mailto:ossinsight@pingcap.com) ✉️
+
+## Development
 
 ```bash
 pnpm install
-pnpm dev
+pnpm dev        # Start web app (port 3001)
+pnpm dev:docs   # Start docs site (port 3002)
+pnpm dev:all    # Start both
 ```
 
-Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
+## Sponsors
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Environment Variables
-
-- `GA_MEASUREMENT_SECRET`: Google Analytics Measurement Protocol secret.
-
-For backward compatibility, the legacy typo `GA_MESUREMENT_SECRET` is still accepted, but new deployments should use `GA_MEASUREMENT_SECRET`.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+<div align="center">
+  <a href="https://en.pingcap.com/tidb-cloud/?utm_source=ossinsight&utm_medium=referral">
+    <img src="https://ossinsight.io/img/tidb-cloud-logo-w.png" height=50 />
+  </a>
+</div>


### PR DESCRIPTION
## Summary

- Restore the original promotional README that was accidentally replaced by a generic Next.js template during the monorepo migration (#1911)
- Fix broken image paths (`/web/static/img/...` → absolute URLs)
- Update dead links (removed `CONTRIBUTING.md`, `configs/collections`)
- Replace development section with current `pnpm` commands

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Check all image URLs load
- [ ] Confirm no dead links


🤖 Generated with [Claude Code](https://claude.com/claude-code)