### PR TITLE
Fix stale homepage data: reduce API CDN cache to 60s

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=@tanstack/*

--- a/apps/web/app/api/q/[...query]/route.ts
+++ b/apps/web/app/api/q/[...query]/route.ts
@@ -28,9 +28,7 @@ export async function GET(req: NextRequest, reqCtx: { params: Promise<Params> })
       status: 200,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
-        'Cache-Control': 'max-age=60',
-        'CDN-Cache-Control': 'max-age=300',
-        'Vercel-CDN-Cache-Control': 'max-age=3600',
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
         ...CORS_HEADERS,
       },
     });

--- a/apps/web/app/q/[...query]/route.ts
+++ b/apps/web/app/q/[...query]/route.ts
@@ -18,9 +18,7 @@ export async function GET(req: NextRequest, reqCtx: { params: Promise<Params> })
       status: 200,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
-        'Cache-Control': 'max-age=60',
-        'CDN-Cache-Control': 'max-age=300',
-        'Vercel-CDN-Cache-Control': 'max-age=3600',
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
Root cause: API route handlers had `Vercel-CDN-Cache-Control: max-age=3600` — Vercel edge CDN cached all `/api/q/` and `/q/` responses for **1 hour**. The real-time homepage counters (events-total, events-increment, bars) showed the same frozen numbers since deployment.

Fix: Replace with `Cache-Control: public, s-maxage=60, stale-while-revalidate=120` — data refreshes every 60s with graceful stale-while-revalidate.

## Test plan
- [ ] Deploy to Vercel
- [ ] Verify homepage numbers update on refresh (within ~60s)
- [ ] Verify bars animate with new data

🤖 Generated with [Claude Code](https://claude.com/claude-code)