### PR TITLE
Remove API response caching

### DIFF
--- a/apps/web/app/api/q/[...query]/route.ts
+++ b/apps/web/app/api/q/[...query]/route.ts
@@ -28,7 +28,7 @@ export async function GET(req: NextRequest, reqCtx: { params: Promise<Params> })
       status: 200,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
+        'Cache-Control': 'no-store',
         ...CORS_HEADERS,
       },
     });

--- a/apps/web/app/q/[...query]/route.ts
+++ b/apps/web/app/q/[...query]/route.ts
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest, reqCtx: { params: Promise<Params> })
       status: 200,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
+        'Cache-Control': 'no-store',
       },
     });
   } catch (error) {


### PR DESCRIPTION
Follow-up to #1917 — remove caching entirely instead of reducing it. API data is real-time GitHub events, no reason to cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)