### PR TITLE
Fix blog/docs header links pointing to localhost

### DIFF
--- a/packages/site-shell/src/site-links.ts
+++ b/packages/site-shell/src/site-links.ts
@@ -18,7 +18,7 @@ function getDefaultOrigin(app: SiteApp) {
 
 export function getSiteAppOrigins(env: EnvMap = process.env): SiteAppOrigins {
   const webOrigin = env.NEXT_PUBLIC_WEB_HOST ?? env.NEXT_PUBLIC_SITE_HOST ?? getDefaultOrigin('web');
-  const docsOrigin = env.NEXT_PUBLIC_DOCS_HOST ?? getDefaultOrigin('docs');
+  const docsOrigin = env.NEXT_PUBLIC_DOCS_HOST ?? env.NEXT_PUBLIC_SITE_HOST ?? getDefaultOrigin('docs');
 
   return {
     web: normalizeOrigin(webOrigin),


### PR DESCRIPTION
## Summary
Blog and docs links in the header showed `http://127.0.0.1:3002/blog` on Vercel because `docsOrigin` didn't fall back to `NEXT_PUBLIC_SITE_HOST`.

Now: `NEXT_PUBLIC_DOCS_HOST` → `NEXT_PUBLIC_SITE_HOST` → localhost fallback.

Since `NEXT_PUBLIC_SITE_HOST=https://ossinsight.io` is already configured on Vercel, links will correctly resolve to `ossinsight.io/blog` and `ossinsight.io/docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)