### PR TITLE
Proxy /blog and /docs through web app via rewrites

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -18,6 +18,18 @@ const nextConfig = {
   async redirects() {
     return []
   },
+  async rewrites() {
+    // Internal docs app URL for proxying — NOT the public-facing host
+    const docsOrigin = process.env.DOCS_ORIGIN || 'http://127.0.0.1:3002';
+    return {
+      beforeFiles: [
+        { source: '/blog', destination: `${docsOrigin}/blog` },
+        { source: '/blog/:path*', destination: `${docsOrigin}/blog/:path*` },
+        { source: '/docs', destination: `${docsOrigin}/docs` },
+        { source: '/docs/:path*', destination: `${docsOrigin}/docs/:path*` },
+      ],
+    };
+  },
   pageExtensions: ['ts', 'tsx', 'mdx'],
   serverExternalPackages: ['@napi-rs/canvas'],
   turbopack: {

--- a/packages/site-shell/src/site-links.ts
+++ b/packages/site-shell/src/site-links.ts
@@ -31,7 +31,9 @@ export function getSiteAppOrigin(app: SiteApp, env: EnvMap = process.env) {
 }
 
 export function getCrossAppHref(currentApp: SiteApp, targetApp: SiteApp, path: string, env: EnvMap = process.env) {
-  if (currentApp === targetApp) {
+  // Web proxies /blog and /docs to docs app via rewrites, so always use relative paths
+  // from web→docs. Only docs→web needs a full origin.
+  if (currentApp === targetApp || (currentApp === 'web' && targetApp === 'docs')) {
     return path;
   }
 


### PR DESCRIPTION
## Summary
- Web app now proxies `/blog/*` and `/docs/*` to the docs app via Next.js `beforeFiles` rewrites
- Header links from web to docs now use relative paths (`/blog`, `/docs/api`) instead of full URLs
- Users visit `ossinsight.io/blog` and see docs content seamlessly — same domain, no redirect

## Setup
Add to web project's Vercel env vars:
```
DOCS_ORIGIN=https://ossinsight-docs.vercel.app
```

Locally, defaults to `http://127.0.0.1:3002` (docs dev server).

## Test plan
- [x] `curl http://127.0.0.1:3001/blog` returns docs blog page (200)
- [ ] Verify on Vercel after setting `DOCS_ORIGIN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)