### PR TITLE
Use Vercel Related Projects for docs URL resolution

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -19,8 +19,18 @@ const nextConfig = {
     return []
   },
   async rewrites() {
-    // Internal docs app URL for proxying — NOT the public-facing host
-    const docsOrigin = process.env.DOCS_ORIGIN || 'http://127.0.0.1:3002';
+    let docsOrigin = 'http://127.0.0.1:3002';
+    try {
+      const { withRelatedProject } = await import('@vercel/related-projects');
+      const host = withRelatedProject({
+        projectName: 'ossinsight-docs',
+        defaultHost: process.env.DOCS_ORIGIN,
+      });
+      if (host) docsOrigin = `https://${host}`;
+    } catch {
+      // Not on Vercel or package unavailable — use env var or localhost
+      if (process.env.DOCS_ORIGIN) docsOrigin = process.env.DOCS_ORIGIN;
+    }
     return {
       beforeFiles: [
         { source: '/blog', destination: `${docsOrigin}/blog` },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "@streamdown/mermaid": "^1.0.2",
     "@tanstack/react-query": "^5.90.21",
     "@tidbcloud/serverless": "^0.0.6",
+    "@vercel/related-projects": "^1.0.1",
     "@xyflow/react": "^12.10.1",
     "ai": "^6.0.116",
     "ansi-to-react": "^6.2.6",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,3 @@
+{
+  "relatedProjects": ["prj_MGvL5diJ4d5aAIxrubFRKA1LGvCp"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@tidbcloud/serverless':
         specifier: ^0.0.6
         version: 0.0.6
+      '@vercel/related-projects':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.1(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
@@ -7472,6 +7475,12 @@ packages:
   /@vercel/oidc@3.1.0:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
+    dev: false
+
+  /@vercel/related-projects@1.0.1:
+    resolution: {integrity: sha512-gCgaY/LHQXue7XaviZqbr1ZGQOhFmBL13fBYkt4Dr+fONyoHH/awH6steYfkwPQyi/479mZ0mQax84p0/bDs5A==}
+    optionalDependencies:
+      ajv: 6.14.0
     dev: false
 
   /@webassemblyjs/ast@1.14.1:


### PR DESCRIPTION
## Summary
Replace manual `DOCS_ORIGIN` env var with Vercel's official Related Projects feature.

- `apps/web/vercel.json` — declares `ossinsight-docs` as a related project
- `@vercel/related-projects` — auto-resolves docs app host per environment (preview matches preview, production matches production)
- No env var needed on Vercel. Falls back to `DOCS_ORIGIN` or `localhost:3002` for local dev.

## Test plan
- [x] Local: `curl http://127.0.0.1:3001/blog` → 200 (proxied from docs on :3002)
- [ ] Vercel: `/blog` and `/docs` proxy to docs app automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)