### PR TITLE
Fix /blog /docs 502: use env var for docs origin

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -19,18 +19,7 @@ const nextConfig = {
     return []
   },
   async rewrites() {
-    let docsOrigin = 'http://127.0.0.1:3002';
-    try {
-      const { withRelatedProject } = await import('@vercel/related-projects');
-      const host = withRelatedProject({
-        projectName: 'ossinsight-docs',
-        defaultHost: process.env.DOCS_ORIGIN,
-      });
-      if (host) docsOrigin = `https://${host}`;
-    } catch {
-      // Not on Vercel or package unavailable — use env var or localhost
-      if (process.env.DOCS_ORIGIN) docsOrigin = process.env.DOCS_ORIGIN;
-    }
+    const docsOrigin = process.env.DOCS_ORIGIN || 'http://127.0.0.1:3002';
     return {
       beforeFiles: [
         { source: '/blog', destination: `${docsOrigin}/blog` },


### PR DESCRIPTION
## Summary
`withRelatedProject()` doesn't work in `rewrites()` because rewrites are evaluated at **build time**, but `VERCEL_RELATED_PROJECTS` is only injected at **runtime**.

Reverted to `DOCS_ORIGIN` env var. Set `DOCS_ORIGIN=https://ossinsight-docs.vercel.app` in Vercel web project env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)