### PR TITLE
Fix /blog /docs: use vercel.json rewrites

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -19,15 +19,20 @@ const nextConfig = {
     return []
   },
   async rewrites() {
-    const docsOrigin = process.env.DOCS_ORIGIN || 'http://127.0.0.1:3002';
-    return {
-      beforeFiles: [
-        { source: '/blog', destination: `${docsOrigin}/blog` },
-        { source: '/blog/:path*', destination: `${docsOrigin}/blog/:path*` },
-        { source: '/docs', destination: `${docsOrigin}/docs` },
-        { source: '/docs/:path*', destination: `${docsOrigin}/docs/:path*` },
-      ],
-    };
+    // Local dev: proxy to docs dev server
+    if (process.env.NODE_ENV === 'development') {
+      const docsOrigin = process.env.DOCS_ORIGIN || 'http://127.0.0.1:3002';
+      return {
+        beforeFiles: [
+          { source: '/blog', destination: `${docsOrigin}/blog` },
+          { source: '/blog/:path*', destination: `${docsOrigin}/blog/:path*` },
+          { source: '/docs', destination: `${docsOrigin}/docs` },
+          { source: '/docs/:path*', destination: `${docsOrigin}/docs/:path*` },
+        ],
+      };
+    }
+    // Production: handled by vercel.json rewrites
+    return [];
   },
   pageExtensions: ['ts', 'tsx', 'mdx'],
   serverExternalPackages: ['@napi-rs/canvas'],

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,3 +1,9 @@
 {
-  "relatedProjects": ["prj_MGvL5diJ4d5aAIxrubFRKA1LGvCp"]
+  "relatedProjects": ["prj_MGvL5diJ4d5aAIxrubFRKA1LGvCp"],
+  "rewrites": [
+    { "source": "/blog", "destination": "https://ossinsight-docs.vercel.app/blog" },
+    { "source": "/blog/:path*", "destination": "https://ossinsight-docs.vercel.app/blog/:path*" },
+    { "source": "/docs", "destination": "https://ossinsight-docs.vercel.app/docs" },
+    { "source": "/docs/:path*", "destination": "https://ossinsight-docs.vercel.app/docs/:path*" }
+  ]
 }


### PR DESCRIPTION
## Summary
Next.js rewrites to `.vercel.app` domains fail with `DNS_HOSTNAME_RESOLVED_PRIVATE` — Vercel blocks serverless functions from resolving internal `.vercel.app` hostnames.

Fix: use `vercel.json` rewrites instead, which route through Vercel's internal network.

- **Vercel (production)**: `vercel.json` rewrites `/blog/*` and `/docs/*` to `ossinsight-docs.vercel.app`
- **Local dev**: Next.js rewrites proxy to `localhost:3002`

No env vars needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)