### PR TITLE
Fix broken CSS on /blog: add docs assetPrefix

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -7,6 +7,7 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  assetPrefix: process.env.NODE_ENV === 'production' ? process.env.DOCS_ASSET_PREFIX : undefined,
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary
When docs pages are served through `ossinsight.io/blog` via rewrites, their `/_next/static/*` assets return 404 because those files belong to the docs build, not web.

Fix: set `assetPrefix` on docs so it references `https://ossinsight-docs.vercel.app` for static assets in production. Already added `DOCS_ASSET_PREFIX` env var to the docs Vercel project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)