### PR TITLE
Fix docs CSS on /blog: hardcode assetPrefix on Vercel

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -7,7 +7,7 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  assetPrefix: process.env.NODE_ENV === 'production' ? process.env.DOCS_ASSET_PREFIX : undefined,
+  assetPrefix: process.env.VERCEL ? 'https://ossinsight-docs.vercel.app' : undefined,
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary
Previous `assetPrefix` using `DOCS_ASSET_PREFIX` env var didn't work — likely a build cache or env timing issue. 

Now uses `process.env.VERCEL` (always available on Vercel builds) to hardcode `https://ossinsight-docs.vercel.app` as asset prefix. This ensures docs CSS/JS loads from the docs domain when pages are served through web's rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)