### PR TITLE
Rewrite /blog-assets to docs for blog images

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,6 +3,7 @@
   "rewrites": [
     { "source": "/blog", "destination": "https://ossinsight-docs.vercel.app/blog" },
     { "source": "/blog/:path*", "destination": "https://ossinsight-docs.vercel.app/blog/:path*" },
+    { "source": "/blog-assets/:path*", "destination": "https://ossinsight-docs.vercel.app/blog-assets/:path*" },
     { "source": "/docs", "destination": "https://ossinsight-docs.vercel.app/docs" },
     { "source": "/docs/:path*", "destination": "https://ossinsight-docs.vercel.app/docs/:path*" }
   ]


### PR DESCRIPTION
Blog post images (e.g. cover SVGs) are in docs' `public/blog-assets/`. When served via `ossinsight.io/blog`, these 404 because web doesn't have them. Add rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)