### PR TITLE
Fix issue leaderboard ordering within each year

### DIFF
--- a/apps/web/lib/data-service/endpoints/collection-issues-history-rank/template.sql
+++ b/apps/web/lib/data-service/endpoints/collection-issues-history-rank/template.sql
@@ -28,5 +28,5 @@ SELECT
 FROM accumulative_issues_by_year acc
 JOIN collection_items ci ON collection_id = 10001 AND ci.repo_id = acc.repo_id
 WHERE row_num_by_year = 1
-ORDER BY t_year
+ORDER BY t_year, total DESC
 ;


### PR DESCRIPTION

## Summary
This fixes the yearly ranking query for issues so repositories are correctly ordered by cumulative issue count within each year.

## What was wrong
The query was only ordering the final result by year, which meant repositories inside the same year were not guaranteed to appear in descending order of `total`.

## What changed
- kept the yearly rank calculation:
  - `ROW_NUMBER() OVER (PARTITION BY t_year ORDER BY total DESC) AS rank`
- updated the final ordering to ensure results are sorted correctly within each year

Changed final ordering from:
```sql
ORDER BY t_year
```

to:

```
ORDER BY t_year, total DESC
```

For each year:
	•	repositories are grouped by t_year
	•	higher total appears first
	•	ranking now matches the displayed order


