### PR TITLE
Fix web app font to use Geist consistently

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -99,7 +99,7 @@
     @apply border-border outline-ring/50;
   }
   html {
-    @apply font-sans;
+    font-family: var(--font-sans), ui-sans-serif, system-ui, -apple-system, sans-serif;
   }
 }
 


### PR DESCRIPTION
## Summary
- Web app header used system font stack instead of Geist font, causing a visible difference with the docs app header
- Changed `html` from `@apply font-sans` (Tailwind default stack) to `font-family: var(--font-sans)` which correctly resolves to Geist

## Test plan
- [ ] Compare headers on /collections and /blog — fonts should now be identical (Geist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)