### PR TITLE
Remove trending-repos live SQL fallback

### DIFF
--- a/apps/web/lib/data-service/routes.ts
+++ b/apps/web/lib/data-service/routes.ts
@@ -135,26 +135,6 @@ async function runTrendingReposQuery(
   }
 
   const nextRequest = loadTrendingReposFromMaterializedView(params)
-    .catch(async (error) => {
-      if (!shouldFallbackToLiveTrendingRepos(error)) {
-        throw error;
-      }
-
-      return createQueryResult(
-        'trending-repos',
-        await executeEndpoint('trending-repos', config, sqlTemplate, params),
-      );
-    })
-    .then(async (result) => {
-      if (result.data.length > 0) {
-        return result;
-      }
-
-      return createQueryResult(
-        'trending-repos',
-        await executeEndpoint('trending-repos', config, sqlTemplate, params),
-      );
-    })
     .then((result) => {
       cachedTrendingRepos.set(cacheKey, {
         expiresAt: Date.now() + TEN_MINUTES,
@@ -258,28 +238,3 @@ LIMIT 100
   } satisfies QueryResult;
 }
 
-function shouldFallbackToLiveTrendingRepos(error: unknown) {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  return /mv_trending_repos|doesn't exist|does not exist|unknown column|unknown table/i.test(error.message);
-}
-
-function createQueryResult(queryName: string, result: Awaited<ReturnType<typeof executeEndpoint>>) {
-  return {
-    query: queryName,
-    params: result.params,
-    sql: result.sql,
-    data: result.data,
-    requestedAt: result.requestedAt,
-    finishedAt: result.finishedAt,
-    spent: result.spent,
-    fields: Object.entries(result.types ?? {}).map(([name, columnType]) => ({
-      name,
-      columnType,
-    })),
-    types: result.types,
-    geo: result.geo,
-  } satisfies QueryResult;
-}


### PR DESCRIPTION
## Summary
- Remove fallback from `mv_trending_repos` to live `template.sql` query for trending-repos endpoint
- Matches the old ossinsight behavior (`onlyFromCache: true`) to avoid heavy query load on the database
- In-memory cache (10min) and request deduplication are preserved

## Test plan
- [ ] Trending repos page still loads from MV
- [ ] If MV has no data, returns error instead of executing expensive SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)