### PR TITLE
config: add omega-memory/omega-memory repo to AI Agent Frameworks collection

### DIFF
--- a/etl/meta/collections/10098.ai-agent-frameworks.yml
+++ b/etl/meta/collections/10098.ai-agent-frameworks.yml
@@ -7,6 +7,7 @@ items:
   - microsoft/autogen
   - agno-agi/agno
   - openai/openai-agents-python
+  - omega-memory/omega-memory
   - pydantic/pydantic-ai
   - yoheinakajima/babyagi
   - Significant-Gravitas/AutoGPT


### PR DESCRIPTION
Adds omega-memory/omega-memory (OMEGA Memory) to the AI Agent Frameworks collection. OMEGA provides persistent memory, coordination, and learning for AI agents with 25 MCP tools.