### PR TITLE
fix: rename collection auth-idp from id 10103 to 10104 to avoid conflict

### DIFF
--- a/configs/collections/10104.authentication-and-idp.yml
+++ b/configs/collections/10104.authentication-and-idp.yml
@@ -1,4 +1,4 @@
-id: 10103
+id: 10104
 name: Authentication and identity providers
 items:
   - ory/kratos


### PR DESCRIPTION
The file `10103.authnticaio-and-idp.yml` was using id 10103 which conflicts with the existing `10103.mocking-stubbing-tools.yml`. This PR renames it to id 10104 and the file to `10104.authentication-and-idp.yml`.