### PR TITLE
feat: add Zig to trending repos language filter

### DIFF
--- a/apps/web/app/home-content.tsx
+++ b/apps/web/app/home-content.tsx
@@ -76,7 +76,7 @@ const languages = [
   'PLpgSQL', 'TSQL', 'Dart', 'Swift', 'HTML', 'CSS', 'Elixir', 'Haskell',
   'Solidity', 'Assembly', 'R', 'Scala', 'Julia', 'Lua', 'Clojure', 'Erlang',
   'Common Lisp', 'Emacs Lisp', 'OCaml', 'MATLAB', 'Objective-C', 'Perl',
-  'Fortran', 'Others',
+  'Fortran', 'Zig', 'Others',
 ];
 const OSSINSIGHT_REPO_QUERY_KEY = ['repo-meta', 'pingcap', 'ossinsight'] as const;
 const ONE_HOUR = 60 * 60 * 1000;

--- a/configs/queries/trending-repos/params.json
+++ b/configs/queries/trending-repos/params.json
@@ -70,7 +70,7 @@
       "replaces": "${language}",
       "default": "All",
       "enums": [
-        "All", "JavaScript", "Java", "Python", "PHP", "C++", "C#", "TypeScript", "Shell", "C", "Ruby", "Rust", "Go", "Kotlin", "HCL", "PowerShell", "CMake", "Groovy", "PLpgSQL", "TSQL", "Dart", "Swift", "HTML", "CSS", "Elixir", "Haskell", "Solidity", "Assembly", "R", "Scala", "Julia", "Lua", "Clojure", "Erlang", "Common Lisp", "Emacs Lisp", "OCaml", "MATLAB", "Objective-C", "Perl", "Fortran"
+        "All", "JavaScript", "Java", "Python", "PHP", "C++", "C#", "TypeScript", "Shell", "C", "Ruby", "Rust", "Go", "Kotlin", "HCL", "PowerShell", "CMake", "Groovy", "PLpgSQL", "TSQL", "Dart", "Swift", "HTML", "CSS", "Elixir", "Haskell", "Solidity", "Assembly", "R", "Scala", "Julia", "Lua", "Clojure", "Erlang", "Common Lisp", "Emacs Lisp", "OCaml", "MATLAB", "Objective-C", "Perl", "Fortran", "Zig"
       ]
     }
   ],


### PR DESCRIPTION
Add Zig to the language filter list in Trending Repos page.

Changes:
- `configs/queries/trending-repos/params.json`: added `Zig` to language enum
- `apps/web/app/home-content.tsx`: added `Zig` to frontend language list

Zig appears in the "Others" dropdown (position 42), no layout/style impact.

Closes #1872