### PR TITLE
fix: timezone defaults & explorer question length validation

### DIFF
--- a/apps/web/app/analyze-user/[login]/_sections/behaviour.tsx
+++ b/apps/web/app/analyze-user/[login]/_sections/behaviour.tsx
@@ -85,7 +85,7 @@ function AllContributions ({ userId }: { userId: number }) {
 function ContributionTime ({ userId }: { userId: number }) {
   const [period, setPeriod] = useState('past_1_year');
   const [type, setType] = useState('all');
-  const [zone, setZone] = useState(0);
+  const [zone, setZone] = useState(() => Math.round(-new Date().getTimezoneOffset() / 60));
 
   const { data } = usePersonalData('personal-contribution-time-distribution', userId, { period });
   const filteredData = useMemo(() => (data ?? []).filter(item => item.type === type), [data, type]);

--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/commits.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/commits.tsx
@@ -93,7 +93,7 @@ export function CommitsSection() {
         Commits Time Distribution
       </h3>
       <p className="text-sm text-gray-500 pb-4">
-        The Heat Maps below describe the number of commit events that occur at a particular point of time (UTC+0).
+        The Heat Maps below describe the number of commit events that occur at a particular point of time.
       </p>
       <div className="flex gap-2 pb-6">
         <HLSelect<string>

--- a/apps/web/app/explore/content.tsx
+++ b/apps/web/app/explore/content.tsx
@@ -1977,10 +1977,17 @@ export function ExploreContent() {
     );
   }, [recommendQuestions, selectedTag]);
 
+  const MAX_QUESTION_LENGTH = 200;
+
   const executeQuestion = useCallback(
     (rawQuestion: string) => {
       const question = rawQuestion.trim();
       if (!question) {
+        return;
+      }
+      if (question.length > MAX_QUESTION_LENGTH) {
+        setErrorMessage(`Question is too long (${question.length} characters). Please keep it under ${MAX_QUESTION_LENGTH} characters.`);
+        setExecutionPhase('idle');
         return;
       }
 


### PR DESCRIPTION
Three small fixes:

### #1540 - User analyze page timezone defaults to browser timezone
`useState(0)` → `useState(() => Math.round(-new Date().getTimezoneOffset() / 60))`

### #1539 - Repo analyze page timezone text consistency  
Removed hardcoded "(UTC+0)" from description text — the actual timezone is shown via the selector.

### #1530 - Explorer question too long error handling
Added client-side validation: questions over 200 characters show a friendly error message instead of failing on the server.

Closes #1539, closes #1540, closes #1530