### PR TITLE
fix: prevent Enter from submitting during IME composition

### DIFF
--- a/apps/web/app/explore/content.tsx
+++ b/apps/web/app/explore/content.tsx
@@ -612,7 +612,7 @@ function ExploreHero({
             disabled={isLoading}
             onChange={(event) => onInputChange(event.currentTarget.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
+              if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
                 event.preventDefault();
                 onSubmit(input);
               }


### PR DESCRIPTION
When using CJK input methods (Chinese, Japanese, Korean), pressing Enter to confirm a character selection incorrectly triggers query submission.

Added `!event.nativeEvent.isComposing` check so Enter during IME composition is ignored.

Closes #1639