### PR TITLE
fix: restore collection CI workflows with lightweight scripts

### DIFF
--- a/.github/workflows/sync-collection-configs.yml
+++ b/.github/workflows/sync-collection-configs.yml
@@ -1,0 +1,33 @@
+name: Sync Collection Configs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'configs/collections/**'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install @tidbcloud/serverless@0.0.6
+
+      - name: Sync all collections
+        run: |
+          for f in configs/collections/*.yml; do
+            id=$(basename "$f" | cut -d. -f1)
+            echo "=== Syncing collection $id ==="
+            node scripts/load-collection.mjs "$id" || echo "⚠ Failed to sync $id, continuing..."
+          done
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/verify-collection-configs.yml
+++ b/.github/workflows/verify-collection-configs.yml
@@ -1,0 +1,28 @@
+name: Verify Collection Configs
+
+on:
+  pull_request:
+    paths:
+      - 'configs/collections/**'
+  push:
+    branches: [main]
+    paths:
+      - 'configs/collections/**'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify Collection Configs
+        run: node scripts/verify-collection.mjs --fix-suggestions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/load-collection.mjs
+++ b/scripts/load-collection.mjs
@@ -62,10 +62,24 @@ console.log(`\nCollection: ${yml.name} (id: ${yml.id})`);
 console.log(`YAML items: ${yml.items.length}`);
 yml.items.forEach(n => console.log(`  ${n}`));
 
-// Load @tidbcloud/serverless from apps/web dependencies
+// Load @tidbcloud/serverless — try multiple locations for compatibility with CI and local dev
 import { createRequire } from 'module';
-const require = createRequire(join(root, 'apps', 'web', 'node_modules', '.pnpm', '@tidbcloud+serverless@0.0.6', 'node_modules', '@tidbcloud', 'serverless', 'package.json'));
-const { connect } = require('@tidbcloud/serverless');
+let connect;
+const searchPaths = [
+  join(root, 'node_modules', '@tidbcloud', 'serverless', 'package.json'),
+  join(root, 'apps', 'web', 'node_modules', '.pnpm', '@tidbcloud+serverless@0.0.6', 'node_modules', '@tidbcloud', 'serverless', 'package.json'),
+];
+for (const p of searchPaths) {
+  try {
+    const req = createRequire(p);
+    connect = req('@tidbcloud/serverless').connect;
+    break;
+  } catch {}
+}
+if (!connect) {
+  console.error('Cannot find @tidbcloud/serverless. Run: npm install @tidbcloud/serverless');
+  process.exit(1);
+}
 const db = connect({
   url: process.env.DATABASE_URL,
   database: process.env.OSSINSIGHT_DATABASE || 'gharchive_dev',

--- a/scripts/verify-collection.mjs
+++ b/scripts/verify-collection.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+/**
+ * Verify collection YAML configs.
+ *
+ * Checks:
+ * 1. YAML format and id uniqueness
+ * 2. Repo names are valid and exist on GitHub
+ * 3. Detects renamed repos and suggests fixes
+ *
+ * Usage:
+ *   node scripts/verify-collection.mjs
+ *   node scripts/verify-collection.mjs --fix-suggestions
+ *
+ * Env:
+ *   GITHUB_ACCESS_TOKENS  comma-separated GitHub tokens (optional, avoids rate limits)
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const collectionsDir = join(root, 'configs', 'collections');
+const showFix = process.argv.includes('--fix-suggestions');
+
+const REPO_NAME_RE = /^[a-zA-Z0-9-]+\/[a-zA-Z0-9._-]{1,100}$/;
+
+// --- Simple YAML parser (same as load-collection.mjs) ---
+function parseCollectionYaml(text) {
+  const lines = text.split('\n');
+  const result = { items: [] };
+  let inItems = false;
+  for (const line of lines) {
+    if (line.startsWith('id:')) result.id = parseInt(line.slice(3).trim());
+    else if (line.startsWith('name:')) result.name = line.slice(5).trim();
+    else if (line.trim() === 'items:') inItems = true;
+    else if (inItems && line.trim().startsWith('- ')) result.items.push(line.trim().slice(2).trim());
+  }
+  return result;
+}
+
+// --- GitHub API with token rotation ---
+const tokens = (process.env.GITHUB_ACCESS_TOKENS || process.env.GITHUB_TOKEN || '')
+  .split(',')
+  .map(t => t.trim())
+  .filter(Boolean);
+let tokenIndex = 0;
+
+async function ghFetch(url) {
+  const headers = { 'User-Agent': 'ossinsight-verify', Accept: 'application/json' };
+  if (tokens.length > 0) {
+    headers.Authorization = `token ${tokens[tokenIndex++ % tokens.length]}`;
+  }
+  // Do NOT follow redirects — we want to detect 301 (renamed repos)
+  const res = await fetch(url, { headers, redirect: 'manual' });
+  return res;
+}
+
+async function checkRepo(repoName) {
+  const res = await ghFetch(`https://api.github.com/repos/${repoName}`);
+  if (res.status === 200) return { exists: true, renamed: false };
+  if (res.status === 301) {
+    // Repo was renamed, follow redirect to get new name
+    const location = res.headers.get('location');
+    if (location) {
+      const follow = await fetch(location, {
+        headers: { 'User-Agent': 'ossinsight-verify', Accept: 'application/json',
+          ...(tokens.length ? { Authorization: `token ${tokens[tokenIndex++ % tokens.length]}` } : {}) },
+      });
+      if (follow.ok) {
+        const data = await follow.json();
+        return { exists: true, renamed: true, newName: data.full_name };
+      }
+    }
+    return { exists: true, renamed: true, newName: null };
+  }
+  if (res.status === 404) return { exists: false, renamed: false };
+  // Rate limited or other error — warn but don't fail
+  console.warn(`  ⚠ GitHub API returned ${res.status} for ${repoName}, skipping check`);
+  return { exists: true, renamed: false }; // Assume OK
+}
+
+// --- Main ---
+const files = readdirSync(collectionsDir).filter(f => f.endsWith('.yml'));
+const configs = files.map(f => {
+  const text = readFileSync(join(collectionsDir, f), 'utf-8');
+  return { file: f, ...parseCollectionYaml(text) };
+});
+
+console.log(`Loaded ${configs.length} collection configs.\n`);
+
+const errors = [];
+const renames = [];
+const idsSeen = new Map(); // id -> filename
+
+// Phase 1: Format & uniqueness checks
+for (const config of configs) {
+  // Check id uniqueness
+  if (idsSeen.has(config.id)) {
+    errors.push(`${config.file}: id ${config.id} conflicts with ${idsSeen.get(config.id)}`);
+  } else {
+    idsSeen.set(config.id, config.file);
+  }
+
+  // Check repo name format
+  const dupes = new Set();
+  for (const repo of config.items) {
+    if (!REPO_NAME_RE.test(repo)) {
+      errors.push(`${config.file}: invalid repo name format "${repo}"`);
+    }
+    if (dupes.has(repo)) {
+      errors.push(`${config.file}: duplicate repo "${repo}"`);
+    }
+    dupes.add(repo);
+  }
+}
+
+// Phase 2: GitHub existence checks (batched with small delay to avoid rate limits)
+const allRepos = [...new Set(configs.flatMap(c => c.items))];
+console.log(`Checking ${allRepos.length} unique repos against GitHub API...\n`);
+
+let checked = 0;
+for (const repo of allRepos) {
+  const result = await checkRepo(repo);
+  checked++;
+  if (checked % 50 === 0) console.log(`  ... checked ${checked}/${allRepos.length}`);
+
+  if (!result.exists) {
+    errors.push(`Repo not found on GitHub: ${repo}`);
+  } else if (result.renamed) {
+    const msg = result.newName
+      ? `Repo renamed: ${repo} → ${result.newName}`
+      : `Repo renamed: ${repo} (could not determine new name)`;
+    errors.push(msg);
+    if (result.newName) renames.push({ old: repo, new: result.newName });
+  }
+
+  // Small delay to be nice to GitHub API
+  if (checked % 10 === 0) await new Promise(r => setTimeout(r, 100));
+}
+
+console.log(`\nChecked ${allRepos.length} repos.\n`);
+
+if (errors.length > 0) {
+  console.error(`❌ ${errors.length} error(s) found:\n`);
+  for (const e of errors) console.error(`  ${e}`);
+
+  if (showFix && renames.length > 0) {
+    console.log(`\n💡 Fix suggestions:\n`);
+    console.log(`cd ${collectionsDir}`);
+    for (const r of renames) {
+      const escaped = (s) => s.replace(/\//g, '\\/');
+      console.log(`find . -name "*.yml" -exec sed -i '' 's/${escaped(r.old)}/${escaped(r.new)}/g' {} +`);
+    }
+  }
+
+  process.exit(1);
+}
+
+console.log(`✅ All ${configs.length} collections passed verification.`);
+process.exit(0);


### PR DESCRIPTION
Restores the collection CI that was lost during the monorepo migration, using lightweight scripts instead of the old `packages/cli`.

### Changes:

**New: `scripts/verify-collection.mjs`**
- Validates YAML format and id uniqueness (no duplicate ids across files)
- Checks all repo names against GitHub API
- Detects renamed repos (301 redirects) and suggests sed fix commands
- Zero dependencies (uses built-in fetch)

**Restored: `.github/workflows/verify-collection-configs.yml`**
- Runs on PRs and pushes to main that touch `configs/collections/`
- Uses `GITHUB_TOKEN` (auto-provided) for API checks

**Restored: `.github/workflows/sync-collection-configs.yml`**
- Auto-syncs collections to TiDB on push to main
- Uses existing `scripts/load-collection.mjs` + `DATABASE_URL` secret
- Installs `@tidbcloud/serverless` on the fly

**Updated: `scripts/load-collection.mjs`**
- Now searches multiple paths for `@tidbcloud/serverless` (works in both CI and local dev)

Closes #1813