### PR TITLE
feat: show project license in Overview section

### DIFF
--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/overview.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/overview.tsx
@@ -7,6 +7,7 @@ import {
   CodeIcon,
   GitCommitIcon,
   IssueOpenedIcon,
+  LawIcon,
   LinkExternalIcon,
   PeopleIcon,
   RepoForkedIcon,
@@ -253,6 +254,13 @@ export function OverviewSection() {
 
             {repoInfo.description ? (
               <p className="mt-3 text-[16px] leading-7 text-[#7c7c7c]">{repoInfo.description}</p>
+            ) : null}
+
+            {repoInfo.license ? (
+              <div className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-[#4d4d4f] px-3 py-1 text-[12px] text-[#d8d8d8]">
+                <LawIcon size={14} />
+                <span>{repoInfo.license}</span>
+              </div>
             ) : null}
 
             {collections.length > 0 ? (

--- a/apps/web/components/Analyze/context.ts
+++ b/apps/web/components/Analyze/context.ts
@@ -9,6 +9,7 @@ export interface RepoInfo {
   full_name: string;
   description: string;
   language: string;
+  license: string;
   forks: number;
   stars: number;
   owner: {

--- a/apps/web/lib/server/internal-api.ts
+++ b/apps/web/lib/server/internal-api.ts
@@ -75,6 +75,7 @@ export async function getRepoById(id: number | string, signal?: AbortSignal) {
     full_name: string;
     description: string;
     language: string;
+    license: string;
     forks: number;
     stars: number;
     owner_login: string;
@@ -87,6 +88,7 @@ export async function getRepoById(id: number | string, signal?: AbortSignal) {
         gr.repo_name AS full_name,
         gr.description,
         gr.primary_language AS language,
+        gr.license,
         gr.forks,
         gr.stars,
         gr.owner_login,
@@ -120,6 +122,7 @@ export async function getRepoByName(owner: string, repo: string, signal?: AbortS
     full_name: string;
     description: string;
     language: string;
+    license: string;
     forks: number;
     stars: number;
     owner_login: string;
@@ -132,6 +135,7 @@ export async function getRepoByName(owner: string, repo: string, signal?: AbortS
         gr.repo_name AS full_name,
         gr.description,
         gr.primary_language AS language,
+        gr.license,
         gr.forks,
         gr.stars,
         gr.owner_login,


### PR DESCRIPTION
## What
Display the repository license as a chip/badge below the description in the Analyze repo overview page.

## How
- Added `license` field to the `RepoInfo` TypeScript interface
- Added a `<Chip>` component with the `LawIcon` below the repo description, showing the SPDX license identifier (e.g. MIT, Apache-2.0)
- Data comes from the existing GitHub API response (`octokit.rest.repos.get`), which already includes the `license` object — no backend changes needed
- Skips display when license is null or `NOASSERTION`

## Files changed
- `web/types/ossinsight.d.ts` — added `license` to `RepoInfo` interface
- `web/src/dynamic-pages/analyze/sections/0-Overview.tsx` — render license badge

Closes #1741