### PR TITLE
fix: remove dangerouslySetInnerHTML XSS risk in company word cloud

### DIFF
--- a/apps/web/charts/analyze/repo/company/visualization.tsx
+++ b/apps/web/charts/analyze/repo/company/visualization.tsx
@@ -113,8 +113,9 @@ export default async function (
             fontFamily="Heiti TC"
             textAnchor="middle"
             transform={`translate(${[word.x, word.y]})rotate(${word.rotate})`}
-            dangerouslySetInnerHTML={{ __html: word.text }}
-          />
+          >
+            {word.text}
+          </text>
         ))}
       </g>
     </svg>


### PR DESCRIPTION
Replace `dangerouslySetInnerHTML={{ __html: word.text }}` with direct text content `{word.text}` in the SVG `<text>` element to prevent potential XSS from company names.

1 file, 3 lines changed.

Closes #1951