### PR TITLE
fix: prefer github_repos.stars over event count for accurate star numbers

### DIFF
--- a/apps/web/lib/data-service/endpoints/analyze-repo-overview/template.sql
+++ b/apps/web/lib/data-service/endpoints/analyze-repo-overview/template.sql
@@ -1,4 +1,13 @@
-WITH stars AS (
+WITH repo_stars AS (
+    SELECT
+        41986369 AS repo_id,
+        stars AS total
+    FROM github_repos
+    WHERE
+        repo_id = 41986369
+        AND is_deleted = 0
+        AND updated_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+), event_stars AS (
     SELECT
         41986369 AS repo_id, IFNULL(COUNT(DISTINCT actor_login), 0) AS total
     FROM github_events
@@ -6,6 +15,13 @@ WITH stars AS (
         type = 'WatchEvent'
         AND repo_id = 41986369
         AND action = 'started'
+), stars AS (
+    SELECT
+        41986369 AS repo_id,
+        COALESCE(
+            (SELECT total FROM repo_stars WHERE repo_id = 41986369),
+            (SELECT total FROM event_stars WHERE repo_id = 41986369)
+        ) AS total
 ), commits AS (
     SELECT
         41986369 AS repo_id, IFNULL(SUM(push_distinct_size), 0) AS total

--- a/configs/queries/analyze-repo-overview/template.sql
+++ b/configs/queries/analyze-repo-overview/template.sql
@@ -1,4 +1,13 @@
-WITH stars AS (
+WITH repo_stars AS (
+    SELECT
+        41986369 AS repo_id,
+        stars AS total
+    FROM github_repos
+    WHERE
+        repo_id = 41986369
+        AND is_deleted = 0
+        AND updated_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+), event_stars AS (
     SELECT
         41986369 AS repo_id, IFNULL(COUNT(DISTINCT actor_login), 0) AS total
     FROM github_events
@@ -6,6 +15,13 @@ WITH stars AS (
         type = 'WatchEvent'
         AND repo_id = 41986369
         AND action = 'started'
+), stars AS (
+    SELECT
+        41986369 AS repo_id,
+        COALESCE(
+            (SELECT total FROM repo_stars WHERE repo_id = 41986369),
+            (SELECT total FROM event_stars WHERE repo_id = 41986369)
+        ) AS total
 ), commits AS (
     SELECT
         41986369 AS repo_id, IFNULL(SUM(push_distinct_size), 0) AS total


### PR DESCRIPTION
## Problem
Star counts in the Analyze overview are derived from counting `WatchEvent` entries in `github_events`. For some repos (e.g. RustFS #1878, Keploy #1894), event ingestion lags behind actual GitHub stats, causing significant undercount.

## Fix
When `github_repos.updated_at` is within the last 7 days, prefer `github_repos.stars` (synced from GitHub API). Otherwise fall back to the event-based count.

Closes #1878
Related: #1894