### PR TITLE
fix: prevent SQL injection in web data-service layer

### DIFF
--- a/apps/web/lib/data-service/executor/server.ts
+++ b/apps/web/lib/data-service/executor/server.ts
@@ -14,6 +14,10 @@ export default async function executeEndpoint (name: string, config: EndpointCon
   const replacedSQL = applyLegacyQueryParameters(config, sqlTemplate, queryParams);
   const sql = await templateEngine.parseAndRender(replacedSQL, queryParams);
 
+  // TODO: Migrate legacy template-based SQL construction to parameterized queries.
+  // Currently the SQL is built via string replacement (applyLegacyQueryParameters)
+  // with values validated by prepareQueryContext (pattern/enum checks).
+  // The stringifyParamValue function escapes quotes for STRING types as a defense layer.
   const start = DateTime.now();
   const result = await tidb.execute(sql, null, {
     fullResult: true,

--- a/apps/web/lib/data-service/executor/utils.ts
+++ b/apps/web/lib/data-service/executor/utils.ts
@@ -142,7 +142,9 @@ function verifyParamValue(param: Params, value: any) {
 function stringifyParamValue(type: ParameterItemType | ParameterType, value: any) {
   switch (type) {
     case ParameterItemType.STRING:
-      return `'${value}'`;
+      // Escape backslashes and single quotes to prevent SQL injection
+      const escaped = String(value).replaceAll('\\', '\\\\').replaceAll("'", "''");
+      return `'${escaped}'`;
     case ParameterItemType.INTEGER:
     case ParameterItemType.NUMBER:
       return `${typeof value === 'string' ? Number(value) : value}`;

--- a/apps/web/lib/data-service/routes.ts
+++ b/apps/web/lib/data-service/routes.ts
@@ -96,6 +96,8 @@ export async function explainQuery(queryName: string, searchParams: URLSearchPar
   const queryParams = getSearchParams(searchParams);
   const context = prepareQueryContext(endpoint.config, queryParams);
   const sql = await templateEngine.parseAndRender(applyLegacyQueryParameters(endpoint.config, endpoint.sql, context), context);
+  // Note: EXPLAIN cannot use parameterized queries for the statement itself,
+  // but the SQL has already been validated through prepareQueryContext + template rendering.
   const explainResult = await executeRows(`EXPLAIN FORMAT = 'brief' ${sql}`, null, signal);
 
   return {
@@ -160,19 +162,15 @@ function getTrendingReposCacheKey(params: Record<string, any>) {
   );
 }
 
-function quoteSQLString(value: string) {
-  return `'${value.replaceAll('\\', '\\\\').replaceAll("'", "''")}'`;
-}
-
 async function loadTrendingReposFromMaterializedView(params: Record<string, any>) {
-  const language = quoteSQLString(String(params.language));
-  const period = quoteSQLString(String(params.period));
+  const language = String(params.language);
+  const period = String(params.period);
   const sql = `
 WITH latest_snapshot AS (
     SELECT MAX(dt) AS dt
     FROM mv_trending_repos
-    WHERE language = ${language}
-      AND period = ${period}
+    WHERE language = ?
+      AND period = ?
 ), repos AS (
     SELECT
         tr.repo_id,
@@ -188,8 +186,8 @@ WITH latest_snapshot AS (
     FROM mv_trending_repos tr
     JOIN latest_snapshot ls ON tr.dt = ls.dt
     JOIN github_repos gr ON tr.repo_id = gr.repo_id
-    WHERE tr.language = ${language}
-      AND tr.period = ${period}
+    WHERE tr.language = ?
+      AND tr.period = ?
 ), repo_with_collections AS (
     SELECT
         r.repo_id,
@@ -219,7 +217,7 @@ LIMIT 100
   `.trim();
 
   const start = DateTime.now();
-  const result = await executeRows(sql);
+  const result = await executeRows(sql, [language, period, language, period]);
   const end = DateTime.now();
 
   return {


### PR DESCRIPTION
## Summary

Fix SQL injection vulnerabilities in the `apps/web` data-service layer that runs on Vercel.

### Changes

**1. `executor/utils.ts` — `stringifyParamValue` escape fix**
- Previously: `'${value}'` — raw string interpolation with no escaping
- Now: Escapes backslashes and single quotes before wrapping in SQL string literals
- This hardens all 76 endpoints that use the legacy `replaces` template system

**2. `routes.ts` — Parameterized queries for trending repos**
- Replaced `quoteSQLString()` string concatenation with `?` placeholders
- `executeRows(sql, [language, period, language, period])` passes values as bind parameters
- Removed the now-unused `quoteSQLString` function entirely

**3. `executor/server.ts` — TODO comment**
- Documents the legacy template architecture and the need for future migration to full parameterized queries

### Security Impact

These changes address SQL injection risks in the Next.js app deployed on Vercel:
- Fixes #1959 
- Fixes #1960 
- Fixes #1963 
- Fixes #1969 
- Fixes #1970 

### Risk Assessment

- **Low risk**: trending-repos params already have strict enums validation, and the new parameterized query is a strict improvement
- **Low risk**: stringifyParamValue escape — all current STRING params have pattern or enums validation; the escape is defense-in-depth
- No behavioral changes for valid inputs