### PR TITLE
fix: restrict CORS to allowed origins instead of wildcard

### DIFF
--- a/apps/web/app/api/q/[...query]/route.ts
+++ b/apps/web/app/api/q/[...query]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { APIError } from '@/lib/data-service';
 import { getQueryName, runQuery } from '@/lib/data-service/routes';
+import { corsHeaders, corsPreflight } from '@/lib/cors';
 
 interface Params {
   query: string | string[];
@@ -8,17 +9,14 @@ interface Params {
 
 export const runtime = 'edge';
 
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-};
-
-export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: CORS_HEADERS });
+export async function OPTIONS(req: NextRequest) {
+  return corsPreflight(req.headers.get('origin'));
 }
 
 export async function GET(req: NextRequest, reqCtx: { params: Promise<Params> }) {
+  const origin = req.headers.get('origin');
+  const cors = corsHeaders(origin);
+
   try {
     const params = await reqCtx.params;
     const queryName = getQueryName(params.query);
@@ -29,7 +27,7 @@ export async function GET(req: NextRequest, reqCtx: { params: Promise<Params> })
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
         'Cache-Control': 'no-store',
-        ...CORS_HEADERS,
+        ...cors,
       },
     });
   } catch (error) {
@@ -38,7 +36,7 @@ export async function GET(req: NextRequest, reqCtx: { params: Promise<Params> })
         status: error.statusCode,
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
-          ...CORS_HEADERS,
+          ...cors,
         },
       });
     }
@@ -48,7 +46,7 @@ export async function GET(req: NextRequest, reqCtx: { params: Promise<Params> })
       status: 500,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
-        ...CORS_HEADERS,
+        ...cors,
       },
     });
   }

--- a/apps/web/lib/cors.ts
+++ b/apps/web/lib/cors.ts
@@ -1,0 +1,58 @@
+/**
+ * Centralized CORS configuration for API routes.
+ *
+ * Reads allowed origins from the CORS_ALLOWED_ORIGINS environment variable
+ * (comma-separated). Falls back to the production origin when not set.
+ */
+
+const DEFAULT_ORIGINS = ['https://ossinsight.io', 'https://www.ossinsight.io'];
+
+function getAllowedOrigins(): string[] {
+  const env = process.env.CORS_ALLOWED_ORIGINS;
+  if (env) {
+    return env.split(',').map((o) => o.trim()).filter(Boolean);
+  }
+  return DEFAULT_ORIGINS;
+}
+
+/**
+ * Build CORS headers for the given request origin.
+ * Returns the origin itself if it is in the allowlist, otherwise the first
+ * allowed origin (browsers will block the response when it doesn't match).
+ *
+ * Pass `origin = '*'` to explicitly allow all origins (public embed APIs).
+ */
+export function corsHeaders(requestOrigin?: string | null): Record<string, string> {
+  const allowed = getAllowedOrigins();
+
+  // When the env explicitly contains '*', allow everything (backwards-compat).
+  if (allowed.includes('*')) {
+    return {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    };
+  }
+
+  const origin =
+    requestOrigin && allowed.includes(requestOrigin)
+      ? requestOrigin
+      : allowed[0];
+
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    Vary: 'Origin',
+  };
+}
+
+/**
+ * Convenience: 204 preflight response.
+ */
+export function corsPreflight(requestOrigin?: string | null) {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders(requestOrigin),
+  });
+}

--- a/apps/web/lib/server/internal-api.ts
+++ b/apps/web/lib/server/internal-api.ts
@@ -1,3 +1,4 @@
+import { corsHeaders } from '@/lib/cors';
 import orgsRecommendList from '@/lib/github-search/recommend/orgs-list.json';
 import reposRecommendList1 from '@/lib/github-search/recommend/repos-list-1.json';
 import reposRecommendList2 from '@/lib/github-search/recommend/repos-list-2.json';
@@ -33,26 +34,15 @@ const COLLECTION_SORTS = new Set<CollectionSort>(['popular', 'az', 'recent']);
 const COLLECTION_METRICS = new Set<CollectionMetric>(['stars', 'pull-requests', 'pull-request-creators', 'issues']);
 const COLLECTION_RANK_RANGES = new Set<CollectionRankRange>(['last-28-days', 'month']);
 
-export function corsPreflightResponse() {
-  return new Response(null, {
-    status: 204,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-    },
-  });
-}
+export { corsPreflight as corsPreflightResponse } from '@/lib/cors';
 
-export function jsonDataResponse(data: unknown, init?: ResponseInit) {
+export function jsonDataResponse(data: unknown, init?: ResponseInit, requestOrigin?: string | null) {
   return new Response(JSON.stringify({ data }), {
     ...init,
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
       'Cache-Control': 'max-age=60',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      ...corsHeaders(requestOrigin),
       ...init?.headers,
     },
   });


### PR DESCRIPTION
## Summary

Replace hardcoded `Access-Control-Allow-Origin: *` with a centralized CORS utility that validates origins against an allowlist.

### Changes

**New: `apps/web/lib/cors.ts`**
- Reads `CORS_ALLOWED_ORIGINS` env var (comma-separated)
- Defaults to `https://ossinsight.io` and `https://www.ossinsight.io`
- Validates request Origin header against the allowlist
- Adds `Vary: Origin` for correct CDN caching
- Set `CORS_ALLOWED_ORIGINS=*` to restore previous wide-open behavior

**Updated: `apps/web/app/api/q/[...query]/route.ts`**
- Uses `corsHeaders(origin)` and `corsPreflight(origin)` instead of hardcoded `*`

**Updated: `apps/web/lib/server/internal-api.ts`**
- `corsPreflightResponse` re-exports from shared utility
- `jsonDataResponse` uses shared `corsHeaders()`

### Vercel Deployment

Add `CORS_ALLOWED_ORIGINS` to Vercel env vars if you need additional origins beyond ossinsight.io. Example:
```
CORS_ALLOWED_ORIGINS=https://ossinsight.io,https://www.ossinsight.io,https://staging.ossinsight.io
```

Fixes #1974