### PR TITLE
feat: add top 1000 repos to sitemap for SEO

### DIFF
--- a/apps/web/app/analyze/sitemap.ts
+++ b/apps/web/app/analyze/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next';
+import { getTopReposForSitemap } from '@/lib/server/internal-api';
+
+const SITE_URL = process.env.SITE_URL || 'https://ossinsight.io';
+
+export const dynamic = 'force-dynamic';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const entries: MetadataRoute.Sitemap = [];
+
+  try {
+    const repos = await getTopReposForSitemap(1000);
+    for (const repo of repos) {
+      const [owner, name] = repo.repo_name.split('/');
+      if (!owner || !name) continue;
+
+      entries.push({
+        url: `${SITE_URL}/analyze/${owner}/${name}`,
+        changeFrequency: 'weekly',
+        priority: 0.7,
+      });
+    }
+  } catch {
+    // Database may be unavailable during build
+  }
+
+  return entries;
+}

--- a/apps/web/lib/server/internal-api.ts
+++ b/apps/web/lib/server/internal-api.ts
@@ -610,6 +610,22 @@ function toCollectionSearchParams(collectionId: number | string) {
   return searchParams;
 }
 
+export async function getTopReposForSitemap(limit = 1000, signal?: AbortSignal) {
+  const { rows } = await executeRows(
+    `
+      SELECT
+        gr.repo_name
+      FROM github_repos gr
+      WHERE gr.is_deleted = 0
+      ORDER BY gr.stars DESC
+      LIMIT :limit
+    `,
+    { limit },
+    signal,
+  );
+  return rows as Array<{ repo_name: string }>;
+}
+
 function mapRecommendRepos(repos: RepoRecommendItem[]) {
   return repos.map((repo) => ({
     id: repo.id,


### PR DESCRIPTION
## Summary

Add the top 1000 most-starred repos to the sitemap so search engines can discover and index their `/analyze/{owner}/{repo}` pages.

### Why

The current sitemap only includes ~3 static pages and collections. The repo analysis pages (`/analyze/facebook/react`, `/analyze/torvalds/linux`, etc.) are the highest-value content on ossinsight.io but are invisible to search engines without sitemap entries.

### Changes

**`apps/web/lib/server/internal-api.ts`**
- New `getTopReposForSitemap(limit)` function: queries top repos by stars

**`apps/web/app/analyze/sitemap.ts`** (new)
- Generates sitemap entries for the top 1000 repos
- Uses Next.js metadata convention → auto included in sitemap index
- `priority: 0.7`, `changeFrequency: weekly`

### Why 1000?

- Covers all major repos that people actually search for
- Stays well under Google's 50k URL / 50MB sitemap limit
- Avoids diluting crawl budget with millions of low-value repos
- Can increase later as needed

### Expected SEO Impact

- ~1000 new indexable pages for high-traffic queries like "react github stats", "linux repo analysis"
- Long-tail keyword coverage for popular open source projects