### PR TITLE
fix: add analyze sitemap to robots.txt

### DIFF
--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -11,6 +11,9 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/api/'],
       },
     ],
-    sitemap: `${SITE_URL}/sitemap.xml`,
+    sitemap: [
+      `${SITE_URL}/sitemap.xml`,
+      `${SITE_URL}/analyze/sitemap.xml`,
+    ],
   };
 }


### PR DESCRIPTION
The `/analyze/sitemap.xml` (top 1000 repos) was not discoverable by search engines because `robots.txt` only pointed to `/sitemap.xml`.

This adds the second sitemap URL to `robots.ts` so crawlers can find both.