### PR TITLE
feat: homepage OG image, language internal links, sitemap 10K repos

### DIFF
--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/overview.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/overview.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from 'react';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import {
   CodeIcon,
@@ -128,6 +129,10 @@ function SummaryTable() {
               <td className="py-3 text-right text-[28px] font-semibold leading-none text-[#e9eaee] tabular-nums">
                 {loading && !item.isStatic ? (
                   <span className="inline-block h-6 w-16 animate-pulse rounded bg-[#343436]" />
+                ) : item.label === 'Language' && item.value && typeof item.value === 'string' ? (
+                  <Link href={`/languages/${encodeURIComponent(item.value)}`} className="hover:text-[#ffe895] transition-colors">
+                    {item.value}
+                  </Link>
                 ) : (
                   formatValue(item.value)
                 )}

--- a/apps/web/app/analyze/sitemap.ts
+++ b/apps/web/app/analyze/sitemap.ts
@@ -9,7 +9,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const entries: MetadataRoute.Sitemap = [];
 
   try {
-    const repos = await getTopReposForSitemap(1000);
+    const repos = await getTopReposForSitemap(10000);
     for (const repo of repos) {
       const [owner, name] = repo.repo_name.split('/');
       if (!owner || !name) continue;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,7 +4,18 @@ import { WebSiteJsonLd, FAQPageJsonLd, OrganizationJsonLd } from '@/components/j
 
 export const metadata: Metadata = {
   title: 'OSSInsight - Open Source Software Insight',
-  description: 'OSSInsight analyzes billions of GitHub events and provides insights for open source software.',
+  description: 'Real-time analytics for 10B+ GitHub events. Analyze any repo, compare projects, and discover trending open source software. Free & open source.',
+  openGraph: {
+    title: 'OSSInsight - Open Source Software Insight',
+    description: 'Real-time analytics for 10B+ GitHub events. Analyze any repo, compare projects, and discover trending open source software.',
+    images: [{ url: '/seo-widgets-homepage.jpeg', width: 1200, height: 630 }],
+  },
+  twitter: {
+    title: 'OSSInsight - Open Source Software Insight',
+    description: 'Real-time analytics for 10B+ GitHub events. Analyze any repo, compare projects, and discover trending open source software.',
+    card: 'summary_large_image',
+    images: ['/seo-widgets-homepage.jpeg'],
+  },
 };
 
 const FAQ_ITEMS = [

--- a/apps/web/lib/server/internal-api.ts
+++ b/apps/web/lib/server/internal-api.ts
@@ -723,13 +723,14 @@ export async function getTrendingRepos(
   }>;
 }
 
-export async function getTopReposForSitemap(limit = 1000, signal?: AbortSignal) {
+export async function getTopReposForSitemap(limit = 10000, signal?: AbortSignal) {
   const { rows } = await executeRows(
     `
       SELECT
         gr.repo_name
       FROM github_repos gr
       WHERE gr.is_deleted = 0
+        AND gr.stars >= 1000
       ORDER BY gr.stars DESC
       LIMIT :limit
     `,


### PR DESCRIPTION
Fixes #2024, Fixes #2044, Fixes #2021

### 1. Homepage OG Image
Use existing `seo-widgets-homepage.jpeg` for og:image and twitter:image. Also improved description.

### 2. Language Internal Link  
Language value in repo analysis overview table now links to `/languages/[language]`. Hover turns gold.

### 3. Sitemap 1K → 10K
- Added `stars >= 1000` filter (efficient index scan)
- Limit raised from 1,000 to 10,000
- 10x more repo pages indexed by Google