### PR TITLE
feat(web): improve internal cross-linking between pages for SEO

### DIFF
--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/overview.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/overview.tsx
@@ -269,20 +269,43 @@ export function OverviewSection() {
               </div>
             ) : null}
 
-            {collections.length > 0 ? (
-              <div className="mt-3 flex flex-wrap items-center gap-2 text-[14px] text-[#7c7c7c]">
-                <span>In Collection:</span>
-                {collections.map((collection) => (
-                  <a
-                    key={collection.id}
-                    href={`/collections/${toCollectionSlug(collection.name)}`}
-                    className="inline-flex items-center rounded-full border border-[#4d4d4f] px-3 py-1 text-[12px] text-[#fbe593] transition hover:border-[#fbe593]/60 hover:text-[#fceeb4]"
-                  >
-                    {collection.name}
-                  </a>
-                ))}
-              </div>
-            ) : null}
+            <nav aria-label="Related pages" className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-[13px] text-[#7c7c7c]">
+              {collections.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-[14px]">In Collection:</span>
+                  {collections.map((collection) => (
+                    <a
+                      key={collection.id}
+                      href={`/collections/${toCollectionSlug(collection.name)}`}
+                      className="inline-flex items-center rounded-full border border-[#4d4d4f] px-3 py-1 text-[12px] text-[#fbe593] transition hover:border-[#fbe593]/60 hover:text-[#fceeb4]"
+                    >
+                      {collection.name}
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                <Link
+                  href="/collections"
+                  className="text-[#7c7c7c] transition-colors hover:text-[#fbe593]"
+                >
+                  Browse Collections →
+                </Link>
+              )}
+              {repoInfo.language && (
+                <Link
+                  href={`/languages/${encodeURIComponent(repoInfo.language)}`}
+                  className="text-[#7c7c7c] transition-colors hover:text-[#fbe593]"
+                >
+                  More {repoInfo.language} repositories →
+                </Link>
+              )}
+              <Link
+                href="/trending"
+                className="text-[#7c7c7c] transition-colors hover:text-[#fbe593]"
+              >
+                Trending repos →
+              </Link>
+            </nav>
           </>
         ) : null}
 

--- a/apps/web/app/collections/[slug]/content.tsx
+++ b/apps/web/app/collections/[slug]/content.tsx
@@ -628,6 +628,22 @@ export function CollectionDetail({ collection, initialRankingData }: { collectio
         <MonthlyRankingSection collectionId={collection.id} initialRankingData={initialRankingData} />
         <HistoryRankSection collectionId={collection.id} collectionName={collection.name} />
       </div>
+
+      <aside aria-label="Related pages" className="mt-12 border-t border-[#2a2a2a] pt-6">
+        <nav className="flex flex-wrap items-center gap-4 text-sm text-[#7c7c7c]">
+          <Link href="/trending" className="transition-colors hover:text-[#f7df83]">
+            Trending Repos →
+          </Link>
+          <span className="text-[#333]">·</span>
+          <Link href="/languages" className="transition-colors hover:text-[#f7df83]">
+            Browse by Language →
+          </Link>
+          <span className="text-[#333]">·</span>
+          <Link href="/collections" className="transition-colors hover:text-[#f7df83]">
+            All Collections →
+          </Link>
+        </nav>
+      </aside>
     </div>
   );
 }

--- a/apps/web/app/languages/[language]/page.tsx
+++ b/apps/web/app/languages/[language]/page.tsx
@@ -269,6 +269,24 @@ export default async function LanguagePage({ params }: PageProps) {
                   View all →
                 </Link>
               </nav>
+
+              <h3 className="mt-8 text-sm font-semibold text-[#7c7c7c] uppercase tracking-wider mb-3">
+                Explore
+              </h3>
+              <nav aria-label="Related pages" className="space-y-1">
+                <Link
+                  href="/trending"
+                  className="block rounded px-2 py-1.5 text-sm text-[#7c7c7c] hover:text-white hover:bg-[#1a1a1a] transition-colors"
+                >
+                  Trending Repos
+                </Link>
+                <Link
+                  href="/collections"
+                  className="block rounded px-2 py-1.5 text-sm text-[#7c7c7c] hover:text-white hover:bg-[#1a1a1a] transition-colors"
+                >
+                  Collections
+                </Link>
+              </nav>
             </div>
           </aside>
         </div>

--- a/apps/web/app/trending/content.tsx
+++ b/apps/web/app/trending/content.tsx
@@ -79,6 +79,17 @@ export function TrendingContent({ repos, period, language, languages, periods }:
         />
       </div>
 
+      {/* Cross-links */}
+      <nav aria-label="Related pages" className="mb-6 flex flex-wrap items-center gap-4 text-sm text-[#7c7c7c]">
+        <Link href="/languages" className="transition-colors hover:text-white">
+          Browse by Language →
+        </Link>
+        <span className="text-[#333]">·</span>
+        <Link href="/collections" className="transition-colors hover:text-white">
+          Browse Collections →
+        </Link>
+      </nav>
+
       {/* Filters */}
       <div className="mb-6 flex flex-wrap items-center gap-4">
         {/* Period tabs */}
@@ -193,13 +204,16 @@ export function TrendingContent({ repos, period, language, languages, periods }:
                           {repo.repo_name}
                         </Link>
                         {repoLang && (
-                          <span className="hidden sm:inline-flex items-center gap-1 shrink-0 rounded-full border border-[#333] px-2 py-0.5 text-[10px] text-[#7c7c7c]">
+                          <Link
+                            href={`/languages/${encodeURIComponent(repoLang)}`}
+                            className="hidden sm:inline-flex items-center gap-1 shrink-0 rounded-full border border-[#333] px-2 py-0.5 text-[10px] text-[#7c7c7c] transition-colors hover:border-[#555] hover:text-white"
+                          >
                             <span
                               className="h-2 w-2 rounded-full"
                               style={{ backgroundColor: LANGUAGE_COLORS[repoLang] ?? '#8b8b8b' }}
                             />
                             {repoLang}
-                          </span>
+                          </Link>
                         )}
                       </div>
                       {repo.description && (


### PR DESCRIPTION
## Summary
Adds semantic cross-links between repo, collection, language, and trending pages to improve SEO crawlability.

### Changes
- **Repo analyze**: Added nav with links to language page, collections, and trending
- **Collection detail**: Added aside footer linking to trending, languages, and all collections
- **Language page**: Added explore section with links to trending and collections
- **Trending page**: Added nav links to languages and collections; made language badges clickable
- All links use semantic HTML (`nav`, `aside` with `aria-label`) for SEO benefit
- Subtle, consistent styling (muted colors with hover effects)

Fixes #2022