### PR TITLE
feat(web): optimize social share text with dynamic stats and hashtags

### DIFF
--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx
@@ -61,8 +61,12 @@ export default async function Page({ params, searchParams }: PageProps) {
       />
       <ShareButtons
         url={`/analyze/${owner}/${repo}`}
-        title={`Check out ${owner}/${repo} analytics on OSSInsight`}
+        title={`${owner}/${repo} — check the full analytics on OSSInsight`}
         className="fixed right-4 top-1/2 -translate-y-1/2 flex-col z-50 bg-gray-900/80 backdrop-blur rounded-lg p-1.5 shadow-lg"
+        stars={repoInfo.stars ?? undefined}
+        forks={repoInfo.forks ?? undefined}
+        language={repoInfo.language ?? undefined}
+        hashtags={['opensource', 'github']}
       />
       <div className="sr-only">
         <h1>{repoInfo.full_name} — GitHub Repository Analytics</h1>

--- a/apps/web/components/ShareButtons.tsx
+++ b/apps/web/components/ShareButtons.tsx
@@ -6,9 +6,21 @@ interface ShareButtonsProps {
   url: string;
   title: string;
   className?: string;
+  stars?: number;
+  forks?: number;
+  language?: string;
+  hashtags?: string[];
 }
 
-export default function ShareButtons({ url, title, className }: ShareButtonsProps) {
+function formatShareText(title: string, { stars, forks }: Pick<ShareButtonsProps, 'stars' | 'forks'>): string {
+  if (stars == null && forks == null) return title;
+  const parts: string[] = [];
+  if (stars != null) parts.push(`${stars.toLocaleString()}⭐`);
+  if (forks != null) parts.push(`${forks.toLocaleString()} forks`);
+  return `📊 ${title} (${parts.join(', ')})`;
+}
+
+export default function ShareButtons({ url, title, className, stars, forks, language, hashtags }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false);
   const [canNativeShare, setCanNativeShare] = useState(false);
 
@@ -20,10 +32,18 @@ export default function ShareButtons({ url, title, className }: ShareButtonsProp
     setCanNativeShare(typeof navigator !== 'undefined' && !!navigator.share);
   }, []);
 
-  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(fullUrl)}&via=OSSInsight`;
+  const richText = formatShareText(title, { stars, forks });
+  const allHashtags = [
+    ...(hashtags ?? []),
+    ...(language ? [language.toLowerCase().replace(/[^a-z0-9]/g, '')] : []),
+  ];
+  const hashtagSuffix = allHashtags.length > 0 ? ` ${allHashtags.map(h => `#${h}`).join(' ')}` : '';
+
+  const twitterText = `${richText}${hashtagSuffix}`;
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(twitterText)}&url=${encodeURIComponent(fullUrl)}&via=OSSInsight`;
   const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(fullUrl)}`;
-  const redditUrl = `https://www.reddit.com/submit?url=${encodeURIComponent(fullUrl)}&title=${encodeURIComponent(title)}`;
-  const hackerNewsUrl = `https://news.ycombinator.com/submitlink?u=${encodeURIComponent(fullUrl)}&t=${encodeURIComponent(title)}`;
+  const redditUrl = `https://www.reddit.com/submit?url=${encodeURIComponent(fullUrl)}&title=${encodeURIComponent(richText)}`;
+  const hackerNewsUrl = `https://news.ycombinator.com/submitlink?u=${encodeURIComponent(fullUrl)}&t=${encodeURIComponent(richText)}`;
 
   const nativeShare = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
Enhances share buttons with dynamic repository statistics for richer social sharing.

### Changes
- **ShareButtons** now accepts optional `stars`, `forks`, `language`, `hashtags` props
- Twitter/X share text includes stats like "📊 owner/repo — 1,234⭐, 567 forks" with hashtags (#opensource #github #python)
- Reddit and Hacker News share URLs use enriched text
- Repo analyze page passes live stats to ShareButtons
- Fully backward-compatible — pages without stats work as before

Fixes #2043