### PR TITLE
feat(web): add skeleton loading states and contextual empty states

### DIFF
--- a/apps/web/app/collections/[slug]/content.tsx
+++ b/apps/web/app/collections/[slug]/content.tsx
@@ -7,8 +7,10 @@ import format from 'human-format';
 import {
   ArrowDown,
   ArrowUp,
+  BarChart3,
   CircleDot,
   GitPullRequest,
+  Inbox,
   Pencil,
   Star,
   UserRound,
@@ -436,7 +438,13 @@ function MonthlyRankingSection({ collectionId, initialRankingData }: { collectio
         </div>
       )}
 
-      {hasLoaded && !loading && !error && rows.length === 0 && <div className="py-10 text-center text-[#7c7c7c]">No data available.</div>}
+      {hasLoaded && !loading && !error && rows.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+          <Inbox className="h-10 w-10 text-[#555]" />
+          <h3 className="text-sm font-medium text-[#7c7c7c]">No ranking data yet</h3>
+          <p className="max-w-sm text-sm text-[#555]">Ranking data for this collection will appear once repositories have enough activity to compare.</p>
+        </div>
+      )}
     </section>
   );
 }
@@ -611,7 +619,13 @@ function HistoryRankSection({ collectionName, collectionId }: { collectionName: 
         </div>
       )}
 
-      {hasLoaded && !loading && !error && rows.length === 0 && <div className="py-10 text-center text-[#7c7c7c]">No data available.</div>}
+      {hasLoaded && !loading && !error && rows.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+          <BarChart3 className="h-10 w-10 text-[#555]" />
+          <h3 className="text-sm font-medium text-[#7c7c7c]">No historical ranking data</h3>
+          <p className="max-w-sm text-sm text-[#555]">Year-to-year ranking history will appear as data accumulates over time.</p>
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/web/app/explore/content.tsx
+++ b/apps/web/app/explore/content.tsx
@@ -15,6 +15,7 @@ import {
   Circle,
   Info,
   CornerDownLeft,
+  Inbox,
   Pause,
   RefreshCcw,
   Share2,
@@ -928,8 +929,10 @@ function ExplorerTable({ answer }: { answer: ExplorerAnswer }) {
 
   if (columns.length === 0) {
     return (
-      <div className="rounded-[14px] border border-dashed border-[#353536] px-4 py-10 text-center text-sm text-[#8c8c8c]">
-        No rows returned for this question.
+      <div className="flex flex-col items-center justify-center gap-3 rounded-[14px] border border-dashed border-[#353536] px-4 py-12 text-center">
+        <Inbox className="h-8 w-8 text-[#555]" />
+        <p className="text-sm font-medium text-[#7c7c7c]">No results found</p>
+        <p className="max-w-sm text-sm text-[#555]">Try rephrasing your question or asking about a different topic.</p>
       </div>
     );
   }

--- a/apps/web/components/Analyze/Section/RepoChart/index.tsx
+++ b/apps/web/components/Analyze/Section/RepoChart/index.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { fetchRepoChartData, type FetchResult } from './endpoints';
 import { ShowSQLButton } from '@/components/Analyze/ShowSQL';
+import { ChartSkeleton } from '@/components/ui/skeletons';
 
 const LazyECharts = dynamic(() => import('@/components/Analyze/EChartsWrapper'), { ssr: false });
 
@@ -112,18 +113,7 @@ export default function RepoChart({
       {ready ? (
         <RepoChartContent vizModule={vizModule} data={fetchResult} ctx={ctx} />
       ) : loading ? (
-        <LazyECharts
-          option={{}}
-          style={{ width: '100%', height: '100%' }}
-          notMerge
-          showLoading
-          loadingOption={{
-            color: 'rgb(255, 232, 149)',
-            textColor: 'rgb(255, 232, 149)',
-            maskColor: 'rgba(0, 0, 0, 0.3)',
-          }}
-          theme="dark"
-        />
+        <ChartSkeleton />
       ) : null}
     </div>
   );

--- a/apps/web/components/Analyze/Table/RankTable.tsx
+++ b/apps/web/components/Analyze/Table/RankTable.tsx
@@ -5,7 +5,8 @@ import {
   getOrgActivityOrgs,
   getCompletionRate,
 } from '@/components/Analyze/utils';
-import Loader from '@/components/Loading';
+import { TableSkeleton as TableSkeletonUI } from '@/components/ui/skeletons';
+import { EmptyState } from '@/components/ui/empty-state';
 import { usePerformanceOptimizedNetworkRequest } from '@/utils/usePerformanceOptimizedNetworkRequest';
 import { Scale } from '@/components/ui/components/transitions';
 import { alpha2ToTitle } from '@/utils/geo';
@@ -72,9 +73,9 @@ export function upperFirst (str: string) {
 
 export const TableSkeleton = forwardRef(function TableSkeleton ({}, forwardedRef: ForwardedRef<any>) {
   return (
-    <>
-      <Loader ref={forwardedRef} />
-    </>
+    <div ref={forwardedRef}>
+      <TableSkeletonUI rows={5} columns={3} />
+    </div>
   );
 });
 
@@ -115,6 +116,8 @@ export function GeoRankTableContent (props: {
     <>
       {loading ? (
         <TableSkeleton ref={ref} />
+      ) : rowsMemo.length === 0 ? (
+        <EmptyState ref={ref} title="No location data available" description="Location data will appear once there is enough activity." className="py-8" />
       ) : (
         <Scale>
           <Table ref={ref} rows={rowsMemo} header={headerMemo} />
@@ -215,6 +218,8 @@ export function CompanyRankTableContent (props: {
     <>
       {loading ? (
         <TableSkeleton ref={ref} />
+      ) : rowsMemo.length === 0 ? (
+        <EmptyState ref={ref} title="No company data available" description="Company data will appear once there is enough activity." className="py-8" />
       ) : (
         <Scale>
           <Table ref={ref} rows={rowsMemo} header={headerMemo} />

--- a/apps/web/components/ui/empty-state.tsx
+++ b/apps/web/components/ui/empty-state.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type ForwardedRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface EmptyStateProps extends React.ComponentProps<'div'> {
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+}
+
+export const EmptyState = forwardRef(function EmptyState(
+  { icon, title, description, className, children, ...props }: EmptyStateProps,
+  ref: ForwardedRef<HTMLDivElement>,
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 py-16 text-center',
+        className,
+      )}
+      {...props}
+    >
+      {icon && <div className="text-[#555]">{icon}</div>}
+      <h3 className="text-sm font-medium text-[#7c7c7c]">{title}</h3>
+      {description && (
+        <p className="max-w-sm text-sm text-[#555]">{description}</p>
+      )}
+      {children}
+    </div>
+  );
+});

--- a/apps/web/components/ui/skeletons.tsx
+++ b/apps/web/components/ui/skeletons.tsx
@@ -1,0 +1,93 @@
+import { cn } from '@/lib/utils';
+import { Skeleton } from './skeleton';
+
+/** A single shimmer bar with sensible defaults for dark backgrounds. */
+function Bar({ className, ...props }: React.ComponentProps<typeof Skeleton>) {
+  return <Skeleton className={cn('bg-white/[0.06]', className)} {...props} />;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Chart skeleton                                                     */
+/* ------------------------------------------------------------------ */
+
+export function ChartSkeleton({
+  className,
+  height = 320,
+}: {
+  className?: string;
+  height?: number;
+}) {
+  return (
+    <div className={cn('flex h-full w-full flex-col gap-3', className)} style={{ minHeight: height }}>
+      {/* Y-axis + chart area */}
+      <div className="flex flex-1 items-end gap-2 px-4 pb-6 pt-4">
+        {/* Y-axis labels */}
+        <div className="flex h-full flex-col justify-between py-1">
+          <Bar className="h-3 w-6" />
+          <Bar className="h-3 w-8" />
+          <Bar className="h-3 w-5" />
+          <Bar className="h-3 w-7" />
+        </div>
+
+        {/* Bars / lines area */}
+        <div className="flex flex-1 items-end justify-around gap-2">
+          {[40, 65, 50, 80, 55, 70, 45, 75, 60, 85, 50, 68].map((h, i) => (
+            <Bar
+              key={i}
+              className="w-full max-w-[32px] rounded-t-sm"
+              style={{ height: `${h}%` }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* X-axis labels */}
+      <div className="flex justify-around px-10">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Bar key={i} className="h-3 w-10" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Table skeleton                                                     */
+/* ------------------------------------------------------------------ */
+
+export function TableSkeleton({
+  rows = 6,
+  columns = 3,
+  className,
+}: {
+  rows?: number;
+  columns?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn('w-full', className)}>
+      {/* Header */}
+      <div className="flex gap-4 border-b border-[#2a2a2c] py-3">
+        {Array.from({ length: columns }).map((_, i) => (
+          <Bar key={i} className={cn('h-4', i === 0 ? 'w-12' : 'flex-1')} />
+        ))}
+      </div>
+
+      {/* Rows */}
+      {Array.from({ length: rows }).map((_, rowIdx) => (
+        <div key={rowIdx} className="flex items-center gap-4 border-b border-[#1f1f20] py-3">
+          {Array.from({ length: columns }).map((_, colIdx) => (
+            <Bar
+              key={colIdx}
+              className={cn(
+                'h-4',
+                colIdx === 0 ? 'w-8' : 'flex-1',
+              )}
+              style={colIdx !== 0 ? { maxWidth: `${70 + ((rowIdx + colIdx) % 3) * 10}%` } : undefined}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Replaces generic spinners with shimmer skeleton loaders and adds meaningful empty states.

### Changes
- **New**: `ChartSkeleton` and `TableSkeleton` components with pulse animation
- **New**: `EmptyState` component with icon, title, and description
- **Repo charts**: Replaced ECharts loading spinner with ChartSkeleton
- **Rank tables**: Replaced basic Loader with TableSkeleton; added empty states for geo/company tables
- **Collection pages**: Contextual empty states for monthly ranking and history sections
- **Explore page**: Enhanced empty search results with icon and guidance text

Fixes #2052