### PR TITLE
feat(web): add PNG/SVG/CSV export buttons for charts and tables

### DIFF
--- a/apps/web/app/collections/[slug]/content.tsx
+++ b/apps/web/app/collections/[slug]/content.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import type { EChartsOption } from 'echarts';
 import { ShowSQLInline } from '@/components/Analyze/ShowSQL';
+import { ExportButton, downloadCsv } from '@/components/ui/export-button';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Table,
@@ -357,9 +358,32 @@ function MonthlyRankingSection({ collectionId, initialRankingData }: { collectio
 
       {!loading && !error && rows.length > 0 && (
         <div className="mt-4">
-          <h3 className="text-center text-[14px] font-semibold text-white">
-            {formatTableTitle(range)} Ranking - {activeMetric?.title}
-          </h3>
+          <div className="flex items-center justify-center gap-2">
+            <h3 className="text-center text-[14px] font-semibold text-white">
+              {formatTableTitle(range)} Ranking - {activeMetric?.title}
+            </h3>
+            <ExportButton
+              options={[{
+                label: 'Download as CSV',
+                onClick: () => {
+                  const headers = isMonthView
+                    ? [formatMonth(rows[0]?.current_month), formatMonth(rows[0]?.last_month), 'Repository', activeMetric?.title ?? '', 'Total']
+                    : ['Last 28 Days Rank', 'Repository', activeMetric?.title ?? '', 'Total'];
+                  const csvRows = rows.map((row) => {
+                    const currentTotal = isMonthView ? row.current_month_total : row.last_period_total;
+                    const currentRank = isMonthView ? row.current_month_rank : row.last_period_rank;
+                    const base = [String(currentRank ?? ''), row.repo_name, String(currentTotal ?? ''), String(row.total ?? '')];
+                    if (isMonthView) {
+                      const previousRank = row.last_month_rank;
+                      return [String(currentRank ?? ''), String(previousRank ?? ''), row.repo_name, String(currentTotal ?? ''), String(row.total ?? '')];
+                    }
+                    return base;
+                  });
+                  downloadCsv(headers, csvRows, `collection-ranking-${metric}-${range}.csv`);
+                },
+              }]}
+            />
+          </div>
 
           <div className="mt-4 overflow-x-auto">
             <Table className="min-w-[860px] border-collapse">

--- a/apps/web/components/Analyze/EChartsWrapper.tsx
+++ b/apps/web/components/Analyze/EChartsWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactEChartsCore from 'echarts-for-react/lib/core';
 import * as echarts from 'echarts/core';
 import {
@@ -25,6 +25,7 @@ import {
 } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
 import map from '@geo-maps/countries-land-10km';
+import { ExportButton, triggerDownload } from '@/components/ui/export-button';
 
 // Must register components BEFORE calling registerMap
 echarts.use([
@@ -52,9 +53,34 @@ if (!echarts.getMap('world')) {
 }
 
 export default function EChartsWrapper({ style, ...props }: any) {
+  const chartRef = useRef<ReactEChartsCore>(null);
+
   // Sanitize style to prevent NaN CSS values
   const safeStyle = style ? Object.fromEntries(
     Object.entries(style).map(([k, v]) => [k, typeof v === 'number' && (isNaN(v) || !isFinite(v)) ? 0 : v])
   ) : style;
-  return <ReactEChartsCore echarts={echarts} style={safeStyle} {...props} />;
+
+  const exportChart = (type: 'png' | 'svg') => {
+    const instance = chartRef.current?.getEchartsInstance();
+    if (!instance) return;
+    const url = instance.getDataURL({
+      type,
+      pixelRatio: type === 'png' ? 2 : 1,
+      backgroundColor: '#0d1117',
+    });
+    triggerDownload(url, `chart.${type}`);
+  };
+
+  return (
+    <div className="group/export relative">
+      <ReactEChartsCore ref={chartRef} echarts={echarts} style={safeStyle} {...props} />
+      <ExportButton
+        className="pointer-events-auto absolute right-2 top-2 opacity-0 transition-opacity group-hover/export:opacity-100"
+        options={[
+          { label: 'Download as PNG', onClick: () => exportChart('png') },
+          { label: 'Download as SVG', onClick: () => exportChart('svg') },
+        ]}
+      />
+    </div>
+  );
 }

--- a/apps/web/components/ui/export-button.tsx
+++ b/apps/web/components/ui/export-button.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Download } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type ExportOption = {
+  label: string;
+  onClick: () => void;
+};
+
+export function ExportButton({
+  options,
+  className,
+}: {
+  options: ExportOption[];
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (ref.current && !ref.current.contains(e.target as Node)) {
+      setOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [open, handleClickOutside]);
+
+  return (
+    <div ref={ref} className={cn('relative inline-flex', className)}>
+      <button
+        type="button"
+        aria-label="Export"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex h-7 w-7 items-center justify-center rounded-md bg-[#1a1a1a]/80 text-[#7c7c7c] backdrop-blur transition hover:bg-[#2a2a2a] hover:text-white"
+      >
+        <Download className="h-3.5 w-3.5" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 min-w-[160px] overflow-hidden rounded-md border border-[#333] bg-[#1a1a1a] py-1 shadow-lg">
+          {options.map((option) => (
+            <button
+              key={option.label}
+              type="button"
+              onClick={() => {
+                option.onClick();
+                setOpen(false);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] text-[#c6c6d0] transition hover:bg-[#2a2a2a] hover:text-white"
+            >
+              <Download className="h-3 w-3" />
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function triggerDownload(dataUrl: string, filename: string) {
+  const link = document.createElement('a');
+  link.href = dataUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export function downloadCsv(headers: string[], rows: string[][], filename: string) {
+  const escape = (val: string) => {
+    if (val.includes(',') || val.includes('"') || val.includes('\n')) {
+      return `"${val.replace(/"/g, '""')}"`;
+    }
+    return val;
+  };
+
+  const csv = [
+    headers.map(escape).join(','),
+    ...rows.map((row) => row.map(escape).join(',')),
+  ].join('\n');
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  triggerDownload(URL.createObjectURL(blob), filename);
+}


### PR DESCRIPTION
Adds export functionality across charts and tables.

### Charts (ECharts)
- Export button appears on hover (top-right corner)
- PNG export at 2x pixel ratio for high quality
- SVG export at native resolution
- Uses ECharts built-in getDataURL() API

### Tables (Collection rankings)
- CSV export button next to table title
- Exports correct columns based on current view (month-to-month vs last-28-days)
- Filename includes metric and range

New component: `components/ui/export-button.tsx`

Fixes #2012