### PR TITLE
Add owasp-noir/noir to security tool collection

### DIFF
--- a/configs/collections/10051.security-tool.yml
+++ b/configs/collections/10051.security-tool.yml
@@ -57,4 +57,4 @@ items:
   - intuitem/ciso-assistant-community
   - safedep/vet
   - hahwul/dalfox
-  
+  - owasp-noir/noir


### PR DESCRIPTION
Hi! adding [noir](https://github.com/owasp-noir/noir) to the security tool collection