### PR TITLE
fix(web): charts squished to 100px on analyze pages

### DIFF
--- a/apps/web/components/Analyze/EChartsWrapper.tsx
+++ b/apps/web/components/Analyze/EChartsWrapper.tsx
@@ -72,7 +72,7 @@ export default function EChartsWrapper({ style, ...props }: any) {
   };
 
   return (
-    <div className="group/export relative">
+    <div className="group/export relative h-full w-full">
       <ReactEChartsCore ref={chartRef} echarts={echarts} style={safeStyle} {...props} />
       <ExportButton
         className="pointer-events-auto absolute right-2 top-2 opacity-0 transition-opacity group-hover/export:opacity-100"


### PR DESCRIPTION
## Problem
All ECharts on `/analyze` pages (commits, PRs, issues, repo stats) are rendered at 100px height instead of their intended height (400px, 300px, etc.), making them appear flat/squished.

## Root Cause
PR #2071 added a wrapper `<div className="group/export relative">` around ECharts for export buttons, but didn't include `h-full w-full`. Since `echarts-for-react` uses `height: 100%` to inherit its container's height, the missing height constraint caused all charts to collapse to ECharts' default minimum (~100px).

## Fix
Add `h-full w-full` to the wrapper div so it properly inherits the parent container's explicit height.

## Before/After
- **Before:** All charts on /analyze/pingcap/tidb are 100px tall (12:1 aspect ratio)
- **After:** Charts render at their intended heights (400px, 300px, etc.)