### PR TITLE
fix(seo): correct canonical URLs and remove duplicate title suffixes

### DIFF
--- a/apps/web/app/analyze-user/[login]/page.tsx
+++ b/apps/web/app/analyze-user/[login]/page.tsx
@@ -38,13 +38,15 @@ export async function generateMetadata ({ params }: { params: Promise<{ login: s
   const { login } = await params;
   const data = await fetchOwnerInfo(decodeURIComponent(login));
   const displayName = data.name || data.login;
-  const title = `Analyze ${displayName} | OSSInsight`;
+  const title = `Analyze ${displayName}`;
+  const fullTitle = `${title} | OSSInsight`;
   const description = `Explore ${displayName}'s open source contributions, code activity, and collaboration metrics with OSSInsight.`;
   return {
     title,
     description,
     keywords: ['OSSInsight', 'developer analytics', 'GitHub', displayName, 'contributions', 'pull requests'],
-    twitter: { title, description, card: 'summary_large_image' },
-    openGraph: { title, description },
+    twitter: { title: fullTitle, description, card: 'summary_large_image' },
+    openGraph: { title: fullTitle, description },
+    alternates: { canonical: `/analyze-user/${data.login}` },
   };
 }

--- a/apps/web/app/analyze/(org)/[owner]/page.tsx
+++ b/apps/web/app/analyze/(org)/[owner]/page.tsx
@@ -52,7 +52,8 @@ export async function generateMetadata ({ params }: { params: Promise<{ owner: s
   const data = await fetchOwnerInfo(decodeURIComponent(owner));
   const displayName = data.name || data.login;
   const isOrg = data.type === 'Organization';
-  const title = `Analyze ${displayName} | OSSInsight`;
+  const title = `Analyze ${displayName}`;
+  const fullTitle = `${title} | OSSInsight`;
   const description = isOrg
     ? 'Unlock the power of time-flexible organization analytics, community recognition metrics, participant insights, and productivity analysis with OSSInsight.'
     : `Explore ${displayName}'s open source contributions, code activity, and collaboration metrics with OSSInsight.`;
@@ -69,13 +70,14 @@ export async function generateMetadata ({ params }: { params: Promise<{ owner: s
       'productivity analysis',
     ],
     twitter: {
-      title,
+      title: fullTitle,
       description,
       card: 'summary_large_image',
     },
     openGraph: {
-      title,
+      title: fullTitle,
       description,
     },
+    alternates: { canonical: `/analyze/${data.login}` },
   };
 }

--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx
@@ -103,8 +103,9 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
   const repo = decodeURIComponent(rawRepo);
   const name = `${owner}/${repo}`;
 
-  const title = `Analyze ${name} | OSSInsight`;
+  const title = `Analyze ${name}`;
 
+  const fullTitle = `${title} | OSSInsight`;
   let description = `Deep insight into the GitHub repository ${name} - stars, commits, pull requests, issues, contributors and more.`;
 
   try {
@@ -124,8 +125,8 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
     title,
     description,
     keywords: ['OSSInsight', 'GitHub', 'analytics', owner, repo],
-    twitter: { title, description, card: 'summary_large_image' },
-    openGraph: { title, description },
+    twitter: { title: fullTitle, description, card: 'summary_large_image' },
+    openGraph: { title: fullTitle, description },
     alternates: { canonical: `/analyze/${owner}/${repo}` },
   };
 }

--- a/apps/web/app/collections/[slug]/page.tsx
+++ b/apps/web/app/collections/[slug]/page.tsx
@@ -14,9 +14,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const collections = await fetchCollections();
   const collection = collections.find((c) => toCollectionSlug(c.name) === slug);
-  if (!collection) return { title: 'Collection Not Found | OSSInsight' };
+  if (!collection) return { title: 'Collection Not Found' };
   return {
-    title: `${collection.name} - Ranking | OSSInsight`,
+    title: `${collection.name} - Ranking`,
     description: COLLECTION_DESC,
     alternates: { canonical: `/collections/${slug}` },
   };

--- a/apps/web/app/collections/[slug]/trends/page.tsx
+++ b/apps/web/app/collections/[slug]/trends/page.tsx
@@ -10,10 +10,11 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const collections = await fetchCollections();
   const collection = collections.find((c) => toCollectionSlug(c.name) === slug);
-  if (!collection) return { title: 'Collection Not Found | OSSInsight' };
+  if (!collection) return { title: 'Collection Not Found' };
   return {
-    title: `${collection.name} - Popularity Trends | OSSInsight`,
+    title: `${collection.name} - Popularity Trends`,
     description: 'The following dynamic charts show the popularity trends of GitHub repositories in this collection. You can display the popularity of repositories based on the number of stars, pull requests, pull request creators, and issues.',
+    alternates: { canonical: `/collections/${slug}/trends` },
   };
 }
 

--- a/apps/web/app/languages/[language]/page.tsx
+++ b/apps/web/app/languages/[language]/page.tsx
@@ -38,15 +38,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {};
   }
 
-  const title = `${language} — Trending GitHub Repos | OSSInsight`;
+  const title = `${language} — Trending GitHub Repos`;
+  const fullTitle = `${title} | OSSInsight`;
   const description = `Discover the most popular and fastest-growing ${language} repositories on GitHub. Real-time rankings powered by 10B+ GitHub events.`;
 
   return {
     title,
     description,
     keywords: ['OSSInsight', 'GitHub', language, 'trending', 'repositories', 'open source'],
-    openGraph: { title, description },
-    twitter: { title, description, card: 'summary_large_image' },
+    openGraph: { title: fullTitle, description },
+    twitter: { title: fullTitle, description, card: 'summary_large_image' },
     alternates: { canonical: `/languages/${encodeURIComponent(language)}` },
   };
 }


### PR DESCRIPTION
## Problem

This PR fixes several SEO issues reported in the GitHub issues:

### #2246 — `/analyze-user/*` pages have wrong canonical URL
**Before:** `curl -s "https://ossinsight.io/analyze-user/torvalds" | grep canonical` returns `href="https://ossinsight.io"`
**After:** returns `href="https://ossinsight.io/analyze-user/torvalds"`

Root cause: The `generateMetadata` function for `analyze-user/[login]/page.tsx` was missing an `alternates.canonical` field, so Next.js fell back to the root layout's `alternates: { canonical: '/' }`, which resolves to the homepage URL.

### #2203 — Duplicate `| OSSInsight` in page titles
**Before:** `<title>Analyze Linus Torvalds | OSSInsight | OSSInsight</title>`
**After:** `<title>Analyze Linus Torvalds | OSSInsight</title>`

Root cause: The root layout has `title.template: '%s | OSSInsight'`. Several page `generateMetadata` functions were returning titles like `Analyze X | OSSInsight` — the template then appended another `| OSSInsight`, doubling it.

Fix: Return just the base title (e.g. `Analyze X`) from page metadata. The `og:title` and `twitter:title` still use the full branded form `Analyze X | OSSInsight` since social cards should show the complete title.

### #2214 — Collection trends pages missing canonical URL
**Before:** `/collections/[slug]/trends` had no `alternates.canonical`, falling back to homepage
**After:** correctly sets `canonical: /collections//trends`

## Files Changed

- `apps/web/app/analyze-user/[login]/page.tsx` — added canonical, fixed title
- `apps/web/app/analyze/(org)/[owner]/page.tsx` — added canonical, fixed title
- `apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx` — fixed title (canonical already present)
- `apps/web/app/collections/[slug]/page.tsx` — fixed title (canonical already present)
- `apps/web/app/collections/[slug]/trends/page.tsx` — added canonical, fixed title
- `apps/web/app/languages/[language]/page.tsx` — fixed title (canonical already present)

## Verification

```bash
# Before (wrong - points to homepage)
curl -s "https://ossinsight.io/analyze-user/torvalds" | grep canonical
# <link rel="canonical" href="https://ossinsight.io"/>

# After (correct)
# <link rel="canonical" href="https://ossinsight.io/analyze-user/torvalds"/>
```

Closes #2246
Closes #2214  
Closes #2203