### PR TITLE
fix(seo): fix duplicate title suffixes, improve blog/compare meta tags

### DIFF
--- a/apps/docs/app/blog/[slug]/page.tsx
+++ b/apps/docs/app/blog/[slug]/page.tsx
@@ -58,6 +58,8 @@ export default async function BlogPostPage({ params }: PageProps) {
         slug={post.slug}
         date={post.date ?? ''}
         authors={post.authors.map((a) => a.name)}
+        image={post.image}
+        keywords={post.tags}
       />
       <div className="mb-8 flex items-center justify-between gap-4">
         <Link

--- a/apps/docs/components/json-ld.tsx
+++ b/apps/docs/components/json-ld.tsx
@@ -15,22 +15,29 @@ export function BlogPostJsonLd({
   slug,
   date,
   authors,
+  image,
+  keywords,
 }: {
   title: string;
   description: string;
   slug: string;
   date: string;
   authors?: string[];
+  image?: string;
+  keywords?: string[];
 }) {
   return (
     <JsonLd
       data={{
         '@context': 'https://schema.org',
-        '@type': 'BlogPosting',
+        '@type': ['BlogPosting', 'TechArticle'],
         headline: title,
         description,
         url: `${SITE_URL}/blog/${slug}`,
         datePublished: date,
+        dateModified: date,
+        ...(image ? { image } : {}),
+        ...(keywords?.length ? { keywords: keywords.join(', ') } : {}),
         ...(authors?.length
           ? { author: authors.map((name) => ({ '@type': 'Person', name })) }
           : {}),
@@ -38,6 +45,19 @@ export function BlogPostJsonLd({
           '@type': 'Organization',
           name: 'OSSInsight',
           url: SITE_URL,
+          logo: {
+            '@type': 'ImageObject',
+            url: `${SITE_URL}/logo.png`,
+          },
+        },
+        isPartOf: {
+          '@type': 'Blog',
+          name: 'OSSInsight Blog',
+          url: `${SITE_URL}/blog`,
+        },
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': `${SITE_URL}/blog/${slug}`,
         },
       }}
     />

--- a/apps/web/app/collections/page.tsx
+++ b/apps/web/app/collections/page.tsx
@@ -10,7 +10,7 @@ import { BreadcrumbListJsonLd } from '@/components/json-ld';
 import { CollectionsList } from './content';
 
 export const metadata: Metadata = {
-  title: 'Explore Collections | OSSInsight',
+  title: 'Explore Collections',
   description: 'Find insights about the monthly or historical rankings and trends in technical fields with curated repository lists.',
 };
 

--- a/apps/web/app/compare/[owner1]/[repo1]/[owner2]/[repo2]/page.tsx
+++ b/apps/web/app/compare/[owner1]/[repo1]/[owner2]/[repo2]/page.tsx
@@ -94,7 +94,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const name1 = `${owner1}/${repo1}`;
   const name2 = `${owner2}/${repo2}`;
-  const title = `${repo1} vs ${repo2} - GitHub Comparison`;
+  const title = `${name1} vs ${name2} — GitHub Comparison`;
+  const fullTitle = `${title} | OSSInsight`;
 
   let description = `Compare ${name1} vs ${name2} — stars, commits, contributors and more.`;
 
@@ -105,7 +106,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     ]);
     if (repoInfo && vsRepoInfo) {
       const nf = new Intl.NumberFormat('en');
-      description = `Compare ${name1} (${nf.format(repoInfo.stars)}\u2B50) vs ${name2} (${nf.format(vsRepoInfo.stars)}\u2B50) — stars, commits, contributors and more.`;
+      description = `Compare ${name1} (${nf.format(repoInfo.stars)}\u2B50) vs ${name2} (${nf.format(vsRepoInfo.stars)}\u2B50) — stars, commits, contributors, pull requests, and more.`;
     }
   } catch {
     // Use default description
@@ -114,9 +115,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description,
-    keywords: ['OSSInsight', 'GitHub', 'comparison', repo1, repo2, owner1, owner2],
-    twitter: { title, description, card: 'summary_large_image' },
-    openGraph: { title, description },
+    keywords: ['OSSInsight', 'GitHub', 'comparison', repo1, repo2, owner1, owner2, name1, name2],
+    twitter: { title: fullTitle, description, card: 'summary_large_image' },
+    openGraph: { title: fullTitle, description },
     alternates: { canonical: `/compare/${owner1}/${repo1}/${owner2}/${repo2}` },
   };
 }

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -4,8 +4,18 @@ import { BreadcrumbListJsonLd } from '@/components/json-ld';
 import { ExploreContent } from './content';
 
 export const metadata: Metadata = {
-  title: 'GitHub Data Explorer: Discover insights in GitHub event data with AI-generated SQL | OSS Insight',
+  title: 'GitHub Data Explorer',
   description: 'Discover insights in GitHub event data with AI-generated SQL and preset visualizations.',
+  openGraph: {
+    title: 'GitHub Data Explorer | OSSInsight',
+    description: 'Discover insights in GitHub event data with AI-generated SQL and preset visualizations.',
+  },
+  twitter: {
+    title: 'GitHub Data Explorer | OSSInsight',
+    description: 'Discover insights in GitHub event data with AI-generated SQL and preset visualizations.',
+    card: 'summary_large_image',
+  },
+  alternates: { canonical: '/explore' },
 };
 
 export default function ExplorePage() {

--- a/apps/web/app/languages/page.tsx
+++ b/apps/web/app/languages/page.tsx
@@ -4,8 +4,17 @@ import { BreadcrumbListJsonLd } from '@/components/json-ld';
 import { LANGUAGES } from '@/lib/server/internal-api';
 
 export const metadata: Metadata = {
-  title: 'Programming Languages on GitHub | OSSInsight',
+  title: 'Programming Languages on GitHub',
   description: 'Explore trending GitHub repositories by programming language. See the hottest projects in JavaScript, Python, Rust, Go, and 37 more languages.',
+  openGraph: {
+    title: 'Programming Languages on GitHub | OSSInsight',
+    description: 'Explore trending GitHub repositories by programming language. See the hottest projects in JavaScript, Python, Rust, Go, and 37 more languages.',
+  },
+  twitter: {
+    title: 'Programming Languages on GitHub | OSSInsight',
+    description: 'Explore trending GitHub repositories by programming language. See the hottest projects in JavaScript, Python, Rust, Go, and 37 more languages.',
+    card: 'summary_large_image',
+  },
   alternates: { canonical: '/languages' },
 };
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,7 +3,9 @@ import { HomeContent } from './home-content';
 import { FAQPageJsonLd } from '@/components/json-ld';
 
 export const metadata: Metadata = {
-  title: 'OSSInsight - Open Source Software Insight',
+  title: {
+    absolute: 'OSSInsight - Open Source Software Insight',
+  },
   description: 'Real-time analytics for 10B+ GitHub events. Analyze any repo, compare projects, and discover trending open source software. Free & open source.',
   openGraph: {
     title: 'OSSInsight - Open Source Software Insight',

--- a/apps/web/app/trending/page.tsx
+++ b/apps/web/app/trending/page.tsx
@@ -12,7 +12,7 @@ export const revalidate = 3600;
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Trending GitHub Repositories | OSSInsight',
+  title: 'Trending GitHub Repositories',
   description: 'Discover the hottest open source projects on GitHub right now. Daily, weekly, and monthly trending repos ranked by community activity, powered by 10B+ GitHub events.',
   keywords: ['GitHub', 'trending', 'repositories', 'open source', 'popular', 'stars', 'OSSInsight'],
   openGraph: {


### PR DESCRIPTION
## Summary

This PR fixes several SEO issues that were missed by PR #2264.

## Issues Fixed

### #2239 — /trending page title duplicate
The `/trending` page had `title: 'Trending GitHub Repositories | OSSInsight'`. The root layout already has `title.template = '%s | OSSInsight'`, causing the final title to be `Trending GitHub Repositories | OSSInsight | OSSInsight`. Fixed by removing the suffix from the static title string (OG/Twitter titles are unaffected — they still show the full branded title).

### #2210 — TechArticle schema for blog posts
Blog posts in `apps/docs` now use `@type: ['BlogPosting', 'TechArticle']` for richer structured data. Additional fields added to `BlogPostJsonLd`:
- `dateModified`
- `image` (from post front matter)
- `keywords` (from post tags)
- `publisher.logo` (ImageObject)
- `isPartOf` (Blog)
- `mainEntityOfPage` (WebPage)

### #2218 — /compare/* pages improved meta tags
Compare page titles now use full `owner/repo` names (e.g. `pingcap/tidb vs facebook/react — GitHub Comparison`) instead of just repo names. OG/Twitter titles now properly show the full branded title with `| OSSInsight`. Keywords expanded to include full repo names.

### Additional title duplicate fixes (same class of bug as #2264)
- `/collections` — removed `| OSSInsight` from static title
- `/explore` — shortened title, added canonical and OG/Twitter tags
- `/languages` — removed `| OSSInsight` from static title, added OG/Twitter
- `/` (home) — use `title.absolute` to bypass the template (home page should not get `OSSInsight - Open Source Software Insight | OSSInsight`)

## Note
- #2249 (/analyze/* dynamic meta) — already done before this PR ✅
- #2179 (BreadcrumbList schema) — already done ✅
- #2176 (WebSite schema with SearchAction) — already done in root layout ✅

## Files Changed
- `apps/web/app/trending/page.tsx`
- `apps/web/app/collections/page.tsx`
- `apps/web/app/explore/page.tsx`
- `apps/web/app/languages/page.tsx`
- `apps/web/app/page.tsx`
- `apps/web/app/compare/[owner1]/[repo1]/[owner2]/[repo2]/page.tsx`
- `apps/docs/components/json-ld.tsx`
- `apps/docs/app/blog/[slug]/page.tsx`