### PR TITLE
feat(web): add visible FAQ section to homepage (#2195)

### DIFF
--- a/apps/web/app/faq-data.ts
+++ b/apps/web/app/faq-data.ts
@@ -1,0 +1,37 @@
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+export const FAQ_ITEMS: FAQItem[] = [
+  {
+    question: 'What is OSSInsight?',
+    answer:
+      'OSSInsight is a free, open-source analytics platform that tracks over 10 billion GitHub events in real time. It provides deep insights into repositories, developers, and organizations — including stars, commits, pull requests, issues, and community health metrics. Powered by TiDB and built by PingCAP.',
+  },
+  {
+    question: 'How does OSSInsight analyze repositories?',
+    answer:
+      'OSSInsight ingests public GitHub event data from GH Archive and stores it in TiDB, a distributed SQL database built to handle billions of rows. When you look up a repository, OSSInsight queries this data in real time to generate a full analytics dashboard.',
+  },
+  {
+    question: 'Is OSSInsight free to use?',
+    answer:
+      'Yes. OSSInsight is completely free and open source. The source code is available on GitHub at github.com/pingcap/ossinsight under an Apache 2.0 license.',
+  },
+  {
+    question: 'What data does OSSInsight use?',
+    answer:
+      'OSSInsight analyzes public GitHub event data archived by GH Archive, including stars, forks, issues, pull requests, commits, pushes, and comments — more than 10 billion events in total.',
+  },
+  {
+    question: 'How often is the data updated?',
+    answer:
+      'Data is updated in near real-time, typically within a few seconds of the event occurring on GitHub.',
+  },
+  {
+    question: 'Can I analyze my own GitHub profile?',
+    answer:
+      'Yes. Enter your GitHub username in the search box and OSSInsight will generate a full developer profile showing your contribution history, starred repositories, programming languages used, and activity trends over time.',
+  },
+];

--- a/apps/web/app/home-content.tsx
+++ b/apps/web/app/home-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { FAQ_ITEMS } from './faq-data';
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
@@ -1300,6 +1301,76 @@ function HotCollectionsSection() {
   );
 }
 
+// --- FAQ Section ---
+
+function FAQSection() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const toggle = useCallback((i: number) => {
+    setOpenIndex((prev) => (prev === i ? null : i));
+  }, []);
+
+  return (
+    <section
+      className="px-6 py-12 max-w-[860px] mx-auto"
+      aria-labelledby="faq-heading"
+    >
+      <h2
+        id="faq-heading"
+        className="text-2xl font-bold mb-2"
+      >
+        ❓ Frequently Asked Questions
+      </h2>
+      <p className="text-gray-400 text-sm mb-8">
+        Everything you need to know about OSSInsight.
+      </p>
+
+      <div className="space-y-2">
+        {FAQ_ITEMS.map((item, i) => {
+          const isOpen = openIndex === i;
+          return (
+            <div
+              key={i}
+              className="rounded-xl border border-white/[0.07] overflow-hidden"
+              style={{ backgroundColor: isOpen ? '#242526' : '#1a1a1b' }}
+            >
+              <button
+                type="button"
+                onClick={() => toggle(i)}
+                aria-expanded={isOpen}
+                className="w-full flex items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ffe895]/50"
+              >
+                <span className="text-[15px] font-medium text-[#e3e3e3]">
+                  {item.question}
+                </span>
+                <span
+                  aria-hidden="true"
+                  className="shrink-0 text-[#ffe895] transition-transform duration-200"
+                  style={{ transform: isOpen ? 'rotate(45deg)' : 'rotate(0deg)' }}
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                </span>
+              </button>
+
+              {isOpen && (
+                <div className="px-5 pb-5">
+                  <div className="h-px bg-white/[0.06] mb-4" />
+                  <p className="text-[14px] leading-relaxed text-slate-300">
+                    {item.answer}
+                  </p>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 // --- Footer ---
 
 function Footer() {
@@ -1404,6 +1475,7 @@ export function HomeContent() {
       <HeroSection />
       <TrendingReposSection />
       <HotCollectionsSection />
+      <FAQSection />
       <Footer />
       <style jsx global>{`
         @keyframes fadeSlideIn {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { HomeContent } from './home-content';
 import { FAQPageJsonLd } from '@/components/json-ld';
+import { FAQ_ITEMS } from './faq-data';
 
 export const metadata: Metadata = {
   title: {
@@ -19,15 +20,6 @@ export const metadata: Metadata = {
     images: ['/seo-widgets-homepage.jpeg'],
   },
 };
-
-const FAQ_ITEMS = [
-  { question: 'What data does OSSInsight analyze?', answer: 'OSSInsight analyzes public GitHub event data archived by GH Archive, including stars, forks, issues, pull requests, commits, and comments — over 10 billion events total.' },
-  { question: 'How often is the data updated?', answer: 'Data is updated in near real-time, typically within a few seconds of the event occurring on GitHub.' },
-  { question: 'Can I analyze any GitHub repository?', answer: 'Yes. Enter any public GitHub repository name in the search box and OSSInsight will generate a full analytics dashboard with stars, commits, contributors, and more.' },
-  { question: 'Is OSSInsight free?', answer: 'Yes, OSSInsight is completely free and open source.' },
-  { question: 'How can I compare two repositories?', answer: 'Go to any repository analysis page and click "VS" or add ?vs=owner/repo to the URL to compare two repositories side by side.' },
-  { question: 'Does OSSInsight have an API?', answer: 'Yes. OSSInsight provides a free public REST API for collection rankings, repository statistics, and more.' },
-];
 
 export default function HomePage() {
   return (


### PR DESCRIPTION
## Summary

Closes #2195

Adds a visible, collapsible FAQ section to the homepage, placed between the Hot Collections section and the footer.

## Changes

### New file: `apps/web/app/faq-data.ts`
Shared module exporting `FAQ_ITEMS` — a single source of truth for the 6 Q&A pairs used by both the visible accordion and the `FAQPageJsonLd` JSON-LD schema.

### `apps/web/app/page.tsx`
- Removed the inline `FAQ_ITEMS` constant (was duplicated here)
- Now imports from `./faq-data` — keeps JSON-LD in sync automatically

### `apps/web/app/home-content.tsx`
- Added `FAQSection` client component with accordion/collapsible Q&A
- Renders before `<Footer />`
- Matches dark theme: bg `#1a1a1b` / `#242526`, text `slate-300`/`#e3e3e3`, accent `#ffe895`
- Accessible: `aria-expanded`, `aria-labelledby`, `focus-visible` ring, semantic `<section>`/`<h2>`

## FAQ Q&A pairs

| Question | |
|---|---|
| What is OSSInsight? | ✅ |
| How does OSSInsight analyze repositories? | ✅ |
| Is OSSInsight free to use? | ✅ |
| What data does OSSInsight use? | ✅ |
| How often is the data updated? | ✅ |
| Can I analyze my own GitHub profile? | ✅ |

## Notes
- FAQPage JSON-LD (from PR #2268) is kept in sync — both use the same `FAQ_ITEMS` export
- Root layout title template (`%s | OSSInsight`) not modified — page title is unchanged
- No new dependencies added; accordion implemented with plain React state