### PR TITLE
collections: add AI Gateways (10142)

### DIFF
--- a/configs/collections/10142.ai-gateways.yml
+++ b/configs/collections/10142.ai-gateways.yml
@@ -1,0 +1,16 @@
+id: 10142
+name: AI Gateways
+items:
+  - Kong/kong
+  - apache/apisix
+  - alibaba/higress
+  - BerriAI/litellm
+  - Portkey-AI/gateway
+  - envoyproxy/ai-gateway
+  - krakend/krakend-ce
+  - APIParkLab/APIPark
+  - Helicone/ai-gateway
+  - agentgateway/agentgateway
+  - maximhq/bifrost
+  - NeuralTrust/TrustGate
+  - EinStack/glide


### PR DESCRIPTION
Adds a curated AI Gateways collection with 13 verified repos (all 500+ stars).

Replaces PR #1898 (which had 3000+ unverified repos and ID conflicts).

Repos: Kong, Apache APISIX, Higress, LiteLLM, Portkey Gateway, Envoy AI Gateway, KrakenD, APIPark, Helicone, AgentGateway, Bifrost, TrustGate, Glide.

Closes #1898