### PR TITLE
fix: clean up requestAnimationFrame in AnimatedCount components

### DIFF
--- a/apps/web/app/explore/content.tsx
+++ b/apps/web/app/explore/content.tsx
@@ -491,6 +491,7 @@ function getChartOption(answer: ExplorerAnswer): EChartsOption | null {
 function AnimatedCount({ value, color = '#9197D0' }: { value: number; color?: string }) {
   const [display, setDisplay] = useState(value);
   const previous = useRef(value);
+  const rafRef = useRef<number>(0);
 
   useEffect(() => {
     const from = previous.current;
@@ -508,11 +509,12 @@ function AnimatedCount({ value, color = '#9197D0' }: { value: number; color?: st
       const eased = 1 - Math.pow(1 - progress, 3);
       setDisplay(Math.round(from + (to - from) * eased));
       if (progress < 1) {
-        requestAnimationFrame(tick);
+        rafRef.current = requestAnimationFrame(tick);
       }
     };
 
-    requestAnimationFrame(tick);
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
   }, [value]);
 
   return (

--- a/apps/web/app/home-content.tsx
+++ b/apps/web/app/home-content.tsx
@@ -91,6 +91,7 @@ function toSlug(name: string) {
 function AnimatedTotal({ value }: { value: number }) {
   const [display, setDisplay] = useState(value);
   const prevRef = useRef(value);
+  const rafRef = useRef<number>(0);
 
   useEffect(() => {
     const from = prevRef.current;
@@ -103,9 +104,10 @@ function AnimatedTotal({ value }: { value: number }) {
       const t = Math.min((now - start) / duration, 1);
       const eased = 1 - Math.pow(1 - t, 3);
       setDisplay(Math.round(from + (to - from) * eased));
-      if (t < 1) requestAnimationFrame(step);
+      if (t < 1) rafRef.current = requestAnimationFrame(step);
     };
-    requestAnimationFrame(step);
+    rafRef.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(rafRef.current);
   }, [value]);
 
   return <span className="text-[#E30C34] font-bold" style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace', fontVariantNumeric: 'tabular-nums' }}>{display.toLocaleString()}</span>;


### PR DESCRIPTION
## Problem
`requestAnimationFrame` calls in AnimatedCount components were not properly cleaned up on unmount, causing memory leaks on long-lived pages.

## Fix
Added `cancelAnimationFrame` cleanup in useEffect return for:
- `apps/web/app/explore/content.tsx` (AnimatedCount)
- `apps/web/app/home-content.tsx` (AnimatedTotal)

Other animation components already had proper cleanup.

Fixes #2460