### PR TITLE
fix: add rel="noopener noreferrer" to all external links

### DIFF
--- a/apps/docs/components/share-buttons.tsx
+++ b/apps/docs/components/share-buttons.tsx
@@ -98,7 +98,7 @@ function ShareButton({
     <a
       href={href}
       target="_blank"
-      rel="noreferrer"
+      rel="noopener noreferrer"
       aria-label={label}
       className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white text-[#212122] transition hover:bg-[#fceeb4]"
     >

--- a/apps/docs/content/blog/unsung-heroes-of-open-source/index.mdx
+++ b/apps/docs/content/blog/unsung-heroes-of-open-source/index.mdx
@@ -24,12 +24,12 @@ Core-js is maintained by [Denis Pushkarev](https://github.com/zloirock), who sta
 <br />
 
 <center>
-<a href="https://ossinsight.io/explore/?id=b21fdc02-c9dc-4dcf-abc4-f74110e784dc" target="_blank">
+<a href="https://ossinsight.io/explore/?id=b21fdc02-c9dc-4dcf-abc4-f74110e784dc" target="_blank" rel="noopener noreferrer">
 <img src="/blog-assets/unsung-heroes-of-open-source/core-js-contributors.png" width="90%" alt="core-js-contributors"/>
 </a>
 </center>
 
-<center><a href="https://ossinsight.io/explore/?id=b21fdc02-c9dc-4dcf-abc4-f74110e784dc" target="_blank"><em>Core-js' top contributors</em></a></center>
+<center><a href="https://ossinsight.io/explore/?id=b21fdc02-c9dc-4dcf-abc4-f74110e784dc" target="_blank" rel="noopener noreferrer"><em>Core-js' top contributors</em></a></center>
 
 <br />
 
@@ -38,13 +38,13 @@ Based on the distribution of contributions to the project, it seems that Denis h
 <br />
 
 <center>
-    <a href="https://ossinsight.io/analyze/zloirock" target="_blank">
+    <a href="https://ossinsight.io/analyze/zloirock" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/core-js-maintainer.png" width="80%" alt="core-js-maintainer"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/analyze/zloirock" target="_blank"><em>Denis' contribution time distribution</em></a>
+    <a href="https://ossinsight.io/analyze/zloirock" target="_blank" rel="noopener noreferrer"><em>Denis' contribution time distribution</em></a>
 </center>
 
 <br />
@@ -53,13 +53,13 @@ Based on the distribution of contributions to the project, it seems that Denis h
 <br />
 
 <center>
-    <a href="https://ossinsight.io/analyze/zloirock/core-js#overview" target="_blank">
+    <a href="https://ossinsight.io/analyze/zloirock/core-js#overview" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/core-js-star.png" width="90%" alt="core-js-star"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/analyze/zloirock/core-js#overview" target="_blank"><em>Core-js' star history</em></a>
+    <a href="https://ossinsight.io/analyze/zloirock/core-js#overview" target="_blank" rel="noopener noreferrer"><em>Core-js' star history</em></a>
 </center>
 
 <br />
@@ -75,13 +75,13 @@ On February 14th, Denis’s blog brought significant attention to the Core-js pr
 <br />
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=12cbe933-d371-435c-83e6-3fe8d46abf76" target="_blank">
+    <a href="https://ossinsight.io/explore/?id=12cbe933-d371-435c-83e6-3fe8d46abf76" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/curl-contributor.png" width="90%" alt="curl-contributor"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=12cbe933-d371-435c-83e6-3fe8d46abf76" target="_blank"><em>cURL's top contributors</em></a>
+    <a href="https://ossinsight.io/explore/?id=12cbe933-d371-435c-83e6-3fe8d46abf76" target="_blank" rel="noopener noreferrer"><em>cURL's top contributors</em></a>
 </center>
 
 <br />
@@ -91,13 +91,13 @@ cURL is primarily maintained by Daniel Stenberg alone, who started working on th
 <br />
 
 <center>
-    <a href="https://ossinsight.io/analyze/bagder" target="_blank">
+    <a href="https://ossinsight.io/analyze/bagder" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/curl-maintainer.png" width="80%" alt="curl-maintainer"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/analyze/bagder" target="_blank"><em>Daniel's contribution time distribution</em></a>
+    <a href="https://ossinsight.io/analyze/bagder" target="_blank" rel="noopener noreferrer"><em>Daniel's contribution time distribution</em></a>
 </center>
 
 <br />
@@ -113,13 +113,13 @@ ImageMagick is a free and open-source software suite for displaying, converting,
 <br />
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=eda659c3-8dfb-41b6-a79e-6ad126797ac1" target="_blank">
+    <a href="https://ossinsight.io/explore/?id=eda659c3-8dfb-41b6-a79e-6ad126797ac1" target="_blank" rel="noopener noreferrer">
     <img src="/blog-assets/unsung-heroes-of-open-source/imagemagick-contributor.png" width="90%" alt="imagemagick-contributor"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=eda659c3-8dfb-41b6-a79e-6ad126797ac1" target="_blank"><em>ImageMagick's top contributors</em></a>
+    <a href="https://ossinsight.io/explore/?id=eda659c3-8dfb-41b6-a79e-6ad126797ac1" target="_blank" rel="noopener noreferrer"><em>ImageMagick's top contributors</em></a>
 </center>
 
 <br />
@@ -129,13 +129,13 @@ ImageMagick is maintained by a small group of developers, including its founder,
 <br />
 
 <center>
-    <a href="https://ossinsight.io/analyze/ImageMagick/ImageMagick#contributors" target="_blank">
+    <a href="https://ossinsight.io/analyze/ImageMagick/ImageMagick#contributors" target="_blank" rel="noopener noreferrer">
     <img src="/blog-assets/unsung-heroes-of-open-source/imagemagick-lastmonth.png" width="90%" alt="imagemagick-lastmonth"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/analyze/ImageMagick/ImageMagick#contributors" target="_blank"><em>ImageMagick's top contributors last month</em></a>
+    <a href="https://ossinsight.io/analyze/ImageMagick/ImageMagick#contributors" target="_blank" rel="noopener noreferrer"><em>ImageMagick's top contributors last month</em></a>
 </center>
 
 <br />
@@ -153,13 +153,13 @@ MyCLI is a command line interface for MySQL, MariaDB, and Percona with auto-comp
 <br />
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=2ec42ec5-b54b-4103-a01a-90fa72af5137" target="_blank">
+    <a href="https://ossinsight.io/explore/?id=2ec42ec5-b54b-4103-a01a-90fa72af5137" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/mycli-contributor.png" width="90%" alt="mycli-contributor"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=2ec42ec5-b54b-4103-a01a-90fa72af5137" target="_blank"><em>MyCLI's top contributors</em></a>
+    <a href="https://ossinsight.io/explore/?id=2ec42ec5-b54b-4103-a01a-90fa72af5137" target="_blank" rel="noopener noreferrer"><em>MyCLI's top contributors</em></a>
 </center>
 
 <br />
@@ -169,13 +169,13 @@ The project is maintained by its creator, Amjith Ramanujam, and contributions fr
 <br />
 
 <center>
-    <a href="https://ossinsight.io/analyze/dbcli/mycli#overview" target="_blank">
+    <a href="https://ossinsight.io/analyze/dbcli/mycli#overview" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/mycli-commit.png" width="90%" alt="mycli-commit"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/analyze/dbcli/mycli#overview" target="_blank"><em>MyCLI's commit history</em></a>
+    <a href="https://ossinsight.io/analyze/dbcli/mycli#overview" target="_blank" rel="noopener noreferrer"><em>MyCLI's commit history</em></a>
 </center>
 
 <br />
@@ -191,13 +191,13 @@ Homebrew is a popular package manager for macOS that allows users to easily inst
 <br />
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=791c5932-ceba-44b0-8a34-d5328a177783" target="_blank">
+    <a href="https://ossinsight.io/explore/?id=791c5932-ceba-44b0-8a34-d5328a177783" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/homebrew-contributor.png" width="90%" alt="homebrew-contributor"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=791c5932-ceba-44b0-8a34-d5328a177783" target="_blank"><em>Homebrew's top contributors</em></a>
+    <a href="https://ossinsight.io/explore/?id=791c5932-ceba-44b0-8a34-d5328a177783" target="_blank" rel="noopener noreferrer"><em>Homebrew's top contributors</em></a>
 </center>
 
 <br />
@@ -215,13 +215,13 @@ Apache Log4j is a powerful logging framework for Java that allows developers to 
 <br />
 
 <center>
-    <a href="https://ossinsight.io/analyze/apache/logging-log4j2#overview" target="_blank">
+    <a href="https://ossinsight.io/analyze/apache/logging-log4j2#overview" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/log4j2-stars.png" width="90%" alt="log4j2-stars"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/analyze/apache/logging-log4j2#overview" target="_blank"><em>Apache Log4j's star history</em></a>
+    <a href="https://ossinsight.io/analyze/apache/logging-log4j2#overview" target="_blank" rel="noopener noreferrer"><em>Apache Log4j's star history</em></a>
 </center>
 
 <br />
@@ -231,13 +231,13 @@ Interestingly, the project did not receive much attention until November 2021, w
 <br />
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=63ea8bae-8155-41d2-864c-795978524a60" target="_blank">
+    <a href="https://ossinsight.io/explore/?id=63ea8bae-8155-41d2-864c-795978524a60" target="_blank" rel="noopener noreferrer">
         <img src="/blog-assets/unsung-heroes-of-open-source/log4j2-contributor.png" width="90%" alt="log4j2-contributor"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=63ea8bae-8155-41d2-864c-795978524a60" target="_blank"><em>Apache Log4j's top contributors</em></a>
+    <a href="https://ossinsight.io/explore/?id=63ea8bae-8155-41d2-864c-795978524a60" target="_blank" rel="noopener noreferrer"><em>Apache Log4j's top contributors</em></a>
 </center>
 
 <br />
@@ -256,13 +256,13 @@ OpenSSL is an open source library that provides cryptographic functions for many
 <br />
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=143a8231-bd81-42c7-bb52-d1e85c61c6a9" target="_blank">
+    <a href="https://ossinsight.io/explore/?id=143a8231-bd81-42c7-bb52-d1e85c61c6a9" target="_blank" rel="noopener noreferrer">
     <img src="/blog-assets/unsung-heroes-of-open-source/openssl-contributor.png" width="90%" alt="openssl-contributor"/>
     </a>
 </center>
 
 <center>
-    <a href="https://ossinsight.io/explore/?id=143a8231-bd81-42c7-bb52-d1e85c61c6a9" target="_blank"><em>OpenSSL's top contributors</em></a>
+    <a href="https://ossinsight.io/explore/?id=143a8231-bd81-42c7-bb52-d1e85c61c6a9" target="_blank" rel="noopener noreferrer"><em>OpenSSL's top contributors</em></a>
 </center>
 
 <br />

--- a/apps/web/app/analyze-user/[login]/_sections/overview.tsx
+++ b/apps/web/app/analyze-user/[login]/_sections/overview.tsx
@@ -27,7 +27,7 @@ export default function OverviewSection () {
   return (
     <>
       {/* -- header -- */}
-      <NextLink target="_blank" href={`https://github.com/${login}`}>
+      <NextLink target="_blank" rel="noopener noreferrer" href={`https://github.com/${login}`}>
         <h1 className="font-semibold text-3xl text-title inline-flex items-center cursor-pointer">
           <NextImage
             src={`https://avatars.githubusercontent.com/u/${userId}`}

--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/overview.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/overview.tsx
@@ -248,7 +248,7 @@ export function OverviewSection() {
                   <a
                     href={`https://github.com/${repoName}`}
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     className="inline-flex items-center gap-1 hover:text-[#fbe593]"
                   >
                     <span className="truncate">{repoName}</span>

--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/pull-requests.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/_sections/pull-requests.tsx
@@ -104,7 +104,7 @@ export function PullRequestsSection() {
         <a
           href="https://github.com/kubernetes/kubernetes/labels?q=size"
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           className="site-link"
         >
           PR size

--- a/apps/web/app/explore/content.tsx
+++ b/apps/web/app/explore/content.tsx
@@ -387,7 +387,7 @@ function renderExplorerCell(column: string, value: unknown) {
         className="text-[#fbe593] transition-colors hover:text-[#fceeb4]"
         href={String(value)}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
       >
         {value}
       </a>
@@ -1354,7 +1354,7 @@ function ExplorerResult({
                     className="site-link"
                     href="https://github.com/pingcap/ossinsight/issues"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                   >
                     report an issue
                   </a>{' '}
@@ -1696,7 +1696,7 @@ function ExploreAdsCard({ href, size = 'default' }: { href: string; size?: 'defa
     <a
       href={href}
       target="_blank"
-      rel="noreferrer"
+      rel="noopener noreferrer"
       className="block rounded-[6px] bg-[linear-gradient(90deg,#FFBCA7_2.21%,#DAA3D8_30.93%,#B587FF_67.95%,#6B7AFF_103.3%)] p-px transition hover:scale-[1.02] hover:shadow-[0_20px_36px_rgba(0,0,0,0.24)]"
     >
         <span className="block rounded-[6px] border border-dashed border-[#1a1a1b]">
@@ -1778,7 +1778,7 @@ function ExploreBottomAdsSection() {
         <a
           href="https://tidbcloud.com/channel?utm_source=ossinsight&utm_medium=referral&utm_campaign=chat2query_202301&utm_content=result_bottom"
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           className="block rounded-[6px] bg-[linear-gradient(90deg,#FFBCA7_2.21%,#DAA3D8_30.93%,#B587FF_67.95%,#6B7AFF_103.3%)] p-px transition hover:scale-[1.02] hover:shadow-[0_20px_36px_rgba(0,0,0,0.24)]"
         >
           <span className="block h-full rounded-[6px] border border-dashed border-[#1a1a1b]">
@@ -1854,11 +1854,11 @@ function ExploreFaqSection() {
       </div>
       <p className="mt-8 text-center text-[16px] text-[#929292]">
         Still having trouble? Contact us, we&apos;re happy to help!{' '}
-        <a className="site-link" href="https://github.com/pingcap/ossinsight/issues" target="_blank" rel="noreferrer">
+        <a className="site-link" href="https://github.com/pingcap/ossinsight/issues" target="_blank" rel="noopener noreferrer">
           GitHub
         </a>{' '}
         {' · '}
-        <a className="site-link" href="https://twitter.com/OSSInsight" target="_blank" rel="noreferrer">
+        <a className="site-link" href="https://twitter.com/OSSInsight" target="_blank" rel="noopener noreferrer">
           Twitter
         </a>
       </p>

--- a/apps/web/components/Analyze/Header/OrgHeader.tsx
+++ b/apps/web/components/Analyze/Header/OrgHeader.tsx
@@ -121,7 +121,7 @@ export function OrgTitleIconEle(props: {
   const WrapperMemo = React.useMemo(() => getWrapper(wrapper), [wrapper]);
 
   return (
-    <NextLink target='_blank' href={`https://github.com/${login}`}>
+    <NextLink target='_blank' rel='noopener noreferrer' href={`https://github.com/${login}`}>
       <WrapperMemo
         className={twMerge(
           'font-semibold text-3xl text-title inline-flex items-center cursor-pointer',

--- a/apps/web/lib/charts-core/renderer/react/builtin/AvatarLabel.tsx
+++ b/apps/web/lib/charts-core/renderer/react/builtin/AvatarLabel.tsx
@@ -79,7 +79,7 @@ export const Wrapper = (
 
   if (href) {
     return (
-      <a href={href} target="_blank" {...rest}>
+      <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
         {children}
       </a>
     );


### PR DESCRIPTION
## Problem
Multiple external links with `target="_blank"` were missing `rel="noopener noreferrer"`, which is a security best practice to prevent tab-napping attacks.

## Fix
Added or updated `rel="noopener noreferrer"` across 8 files including blog MDX, AvatarLabel, OrgHeader, analyze pages, explore content, and share buttons.

Fixes #2432, #2450, #2465, #2466