### PR TITLE
feat: optimize SEO meta tags for collections and language pages

### DIFF
--- a/apps/web/app/collections/page.tsx
+++ b/apps/web/app/collections/page.tsx
@@ -11,11 +11,25 @@ import { toCollectionSlug } from '@/lib/collections';
 import { CollectionsList } from './content';
 
 export const metadata: Metadata = {
-  title: 'Explore Collections',
-  description: 'Find insights about the monthly or historical rankings and trends in technical fields with curated repository lists.',
+  title: 'Open Source Collections — AI Agent Frameworks, GitHub Trending & More',
+  description: 'Browse curated collections of trending GitHub repositories: AI agent frameworks, LLM tools, open source databases, web frameworks, and more. Monthly rankings with historical trends since 2011.',
+  keywords: [
+    'open source collections', 'GitHub trending', 'AI agent frameworks',
+    'LLM tools', 'open source repositories', 'GitHub rankings',
+    'trending repositories 2026', 'open source projects',
+  ],
   alternates: {
     // Canonical strips query params (page, sort, q) to avoid duplicate content
     canonical: '/collections',
+  },
+  openGraph: {
+    title: 'Open Source Collections — AI Agent Frameworks, GitHub Trending & More | OSSInsight',
+    description: 'Browse curated collections of trending GitHub repositories: AI agent frameworks, LLM tools, open source databases, web frameworks, and more.',
+  },
+  twitter: {
+    title: 'Open Source Collections — AI Agent Frameworks, GitHub Trending & More | OSSInsight',
+    description: 'Browse curated collections of trending GitHub repositories: AI agent frameworks, LLM tools, open source databases, web frameworks, and more.',
+    card: 'summary_large_image',
   },
   robots: {
     index: true,

--- a/apps/web/app/languages/[language]/page.tsx
+++ b/apps/web/app/languages/[language]/page.tsx
@@ -38,14 +38,19 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {};
   }
 
-  const title = `${language} — Trending GitHub Repos`;
+  const year = new Date().getFullYear();
+  const title = `Top ${language} GitHub Repositories ${year} — Trending Open Source Projects`;
   const fullTitle = `${title} | OSSInsight`;
-  const description = `Discover the most popular and fastest-growing ${language} repositories on GitHub. Real-time rankings powered by 10B+ GitHub events.`;
+  const description = `Discover the most popular and fastest-growing ${language} repositories on GitHub in ${year}. Real-time rankings of top ${language} open source projects powered by 10B+ GitHub events.`;
 
   return {
     title,
     description,
-    keywords: ['OSSInsight', 'GitHub', language, 'trending', 'repositories', 'open source'],
+    keywords: [
+      `${language} GitHub repos ${year}`, `top ${language} repositories`,
+      `${language} open source projects ${year}`, `trending ${language} repos`,
+      'GitHub', language, 'trending', 'repositories', 'open source', 'OSSInsight',
+    ],
     openGraph: { title: fullTitle, description },
     twitter: { title: fullTitle, description, card: 'summary_large_image' },
     alternates: { canonical: `/languages/${encodeURIComponent(language)}` },


### PR DESCRIPTION
## Changes

### /collections page (#2455)
- Added descriptive meta title with AI agent framework keywords
- Added meta description targeting trending open source search queries
- Added keywords, OpenGraph, and Twitter card metadata

### /collections/[language] pages (#2480)
- Programmatic meta tags with dynamic language name and current year
- Title pattern: 'Top [Language] GitHub Repositories 2026'
- Year-specific keywords for long-tail SEO

Fixes #2455, #2480