### PR TITLE
fix: add error logging to empty catch blocks in visualization components

### DIFF
--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx
@@ -121,8 +121,8 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
       if (repoInfo.language) parts.push(repoInfo.language);
       description = `${parts.join(' · ')}. ${repoInfo.description || `Real-time analytics on stars, commits, issues, pull requests, and contributors.`}`;
     }
-  } catch {
-    // Use default description
+  } catch (error) {
+    console.warn(`[analyze/${owner}/${repo}] Failed to fetch repo info for metadata:`, error);
   }
 
   return {

--- a/apps/web/app/analyze/sitemap.ts
+++ b/apps/web/app/analyze/sitemap.ts
@@ -20,8 +20,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         priority: 0.7,
       });
     }
-  } catch {
-    // Database may be unavailable during build
+  } catch (error) {
+    console.warn('[analyze/sitemap] Failed to fetch top repos for sitemap:', error);
   }
 
   return entries;

--- a/apps/web/app/collections/[slug]/opengraph-image.tsx
+++ b/apps/web/app/collections/[slug]/opengraph-image.tsx
@@ -28,8 +28,8 @@ export default async function Image({ params }: { params: Promise<{ slug: string
         .slice(0, 5)
         .map((p) => p.repo_name.split('/')[1] ?? p.repo_name);
     }
-  } catch {
-    // DB unavailable, use slug-derived name
+  } catch (error) {
+    console.warn(`[collections/${slug}/opengraph-image] Failed to fetch collection data:`, error);
   }
 
   const poppinsMedium = fetch(new URL('./Poppins-Medium.ttf', import.meta.url)).then((r) =>

--- a/apps/web/app/collections/[slug]/page.tsx
+++ b/apps/web/app/collections/[slug]/page.tsx
@@ -51,8 +51,8 @@ export default async function CollectionSlugPage({ params }: { params: Promise<{
         .reduce((acc, row) => acc + (typeof row.total === 'number' ? row.total : 0), 0);
       if (sum > 0) totalStarsInCollection = sum;
     }
-  } catch {
-    // DB unavailable, client will fetch
+  } catch (error) {
+    console.warn(`[collections/${slug}] Failed to pre-fetch ranking data:`, error);
   }
 
   const collectionFaq = [

--- a/apps/web/app/compare/[owner1]/[repo1]/[owner2]/[repo2]/page.tsx
+++ b/apps/web/app/compare/[owner1]/[repo1]/[owner2]/[repo2]/page.tsx
@@ -108,8 +108,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       const nf = new Intl.NumberFormat('en');
       description = `Compare ${name1} (${nf.format(repoInfo.stars)}\u2B50) vs ${name2} (${nf.format(vsRepoInfo.stars)}\u2B50) — stars, commits, contributors, pull requests, and more.`;
     }
-  } catch {
-    // Use default description
+  } catch (error) {
+    console.warn(`[compare] Failed to fetch repo info for ${name1} vs ${name2} metadata:`, error);
   }
 
   return {

--- a/apps/web/app/llms-full.txt/route.ts
+++ b/apps/web/app/llms-full.txt/route.ts
@@ -69,8 +69,8 @@ Curated lists of GitHub repositories grouped by technology domain. Each collecti
       (c: { name: string }) => `- [${c.name}](${SITE_URL}/collections/${toCollectionSlug(c.name)})`,
     );
     sections.push(`### Available Collections (${collections.length} total)\n\n${collectionLines.join('\n')}`);
-  } catch {
-    // DB unavailable
+  } catch (error) {
+    console.warn('[llms-full.txt] Failed to fetch collections:', error);
   }
 
   sections.push(`---

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -49,8 +49,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         priority: 0.5,
       });
     }
-  } catch {
-    // Database may be unavailable during build
+  } catch (error) {
+    console.warn('[sitemap] Failed to fetch collections for sitemap:', error);
   }
 
   // Repo comparisons generated from collections (top repos in each collection, pairwise)
@@ -83,8 +83,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         }
       }
     }
-  } catch {
-    // Database may be unavailable during build
+  } catch (error) {
+    console.warn('[sitemap] Failed to fetch comparison repos for sitemap:', error);
   }
 
   return entries;


### PR DESCRIPTION
Added `console.warn` with contextual messages to 8 empty catch blocks across 7 files. Intentionally silent catches (JSON.parse fallbacks, clipboard cancellation, etc.) were left as-is.

Fixes #2482