### PR TITLE
fix: remove console.log from production code

### DIFF
--- a/apps/web/charts/analyze/org/activity-action-top-repos/visualization.ts
+++ b/apps/web/charts/analyze/org/activity-action-top-repos/visualization.ts
@@ -187,7 +187,6 @@ export const eventHandlers = [
     type: 'click',
     option: 'xAxis.category',
     handler: (params) => {
-      console.log(params)
       if (params?.value) {
         window.open(`/analyze/${params.value}`);
       }


### PR DESCRIPTION
Removed `console.log(params)` from `apps/web/charts/analyze/org/activity-action-top-repos/visualization.ts`.

Fixes #2416