### PR TITLE
fix: add avatar_url to OwnerInfo type

### DIFF
--- a/apps/web/components/Analyze/utils.ts
+++ b/apps/web/components/Analyze/utils.ts
@@ -17,6 +17,7 @@ export interface OwnerInfo {
   id: number;
   bio: string;
   public_repos: number;
+  avatar_url: string;
 }
 
 export const getOwnerInfo = (owner: string): Promise<OwnerInfo> => {


### PR DESCRIPTION
Added `avatar_url: string` to the `OwnerInfo` interface in `apps/web/components/Analyze/utils.ts`.

Fixes #2404