### PR TITLE
fix: correct cache import in fetchOwner.tsx

### DIFF
--- a/apps/web/app/analyze/(org)/[owner]/fetchOwner.tsx
+++ b/apps/web/app/analyze/(org)/[owner]/fetchOwner.tsx
@@ -1,6 +1,6 @@
 import { getOwnerInfo } from '@/components/Analyze/utils';
 import { notFound } from 'next/navigation';
-import { cache } from 'react';
+import { cache } from 'next/cache';
 
 export const fetchOwnerInfo = cache(async (
   orgName: string,


### PR DESCRIPTION
Changed `import { cache } from 'react'` to `import { cache } from 'next/cache'` — React 18.2.0 types don't export `cache`.

Fixes #2410