### PR TITLE
fix: add missing CollectionSelector component

### DIFF
--- a/apps/web/components/ui/components/CollectionSelector/CollectionSelector.tsx
+++ b/apps/web/components/ui/components/CollectionSelector/CollectionSelector.tsx
@@ -1,0 +1,52 @@
+import { RemoteSelector, RemoteSelectorProps } from '../RemoteSelector';
+import { RemoteSelectItem, RemoteSelectorListItemProps } from '../RemoteSelector';
+import { RemoteSelectedItem, RemoteSelectedItemCommonProps } from '../RemoteSelector';
+import { getCollectionText, isCollectionEquals, searchCollections } from './utils';
+
+export type CollectionInfo = {
+  id: number;
+  name: string;
+};
+
+export interface CollectionSelectorProps extends Pick<RemoteSelectorProps<any>, 'id' | 'renderInput'> {
+  collection: CollectionInfo | undefined;
+  onCollectionSelected: (collection: CollectionInfo | undefined) => void;
+}
+
+export function CollectionSelector({ collection, onCollectionSelected, ...props }: CollectionSelectorProps) {
+  return (
+    <RemoteSelector<CollectionInfo>
+      {...props}
+      getItemText={getCollectionText}
+      value={collection ? [collection] : []}
+      onSelect={onCollectionSelected}
+      getRemoteOptions={searchCollections}
+      executeOnMount
+      renderSelectedItems={([item]) => (
+        <CollectionItem id={props.id} item={item} onClear={() => onCollectionSelected(undefined)} />
+      )}
+      renderListItem={itemProps => <CollectionListItem key={itemProps.item.id} {...itemProps} />}
+      equals={isCollectionEquals}
+    />
+  );
+}
+
+function CollectionItem({ item, ...props }: RemoteSelectedItemCommonProps & { item: CollectionInfo }) {
+  return (
+    <RemoteSelectedItem {...props}>
+      <span className="overflow-hidden whitespace-nowrap text-ellipsis">
+        {item.name}
+      </span>
+    </RemoteSelectedItem>
+  );
+}
+
+function CollectionListItem({ item, ...props }: RemoteSelectorListItemProps<CollectionInfo>) {
+  return (
+    <RemoteSelectItem {...props}>
+      <span className="overflow-hidden whitespace-nowrap text-ellipsis">
+        {item.name}
+      </span>
+    </RemoteSelectItem>
+  );
+}

--- a/apps/web/components/ui/components/CollectionSelector/index.ts
+++ b/apps/web/components/ui/components/CollectionSelector/index.ts
@@ -1,0 +1,1 @@
+export * from './CollectionSelector';

--- a/apps/web/components/ui/components/CollectionSelector/utils.ts
+++ b/apps/web/components/ui/components/CollectionSelector/utils.ts
@@ -1,0 +1,26 @@
+import { API_SERVER } from '@/utils/api';
+import { CollectionInfo } from './CollectionSelector';
+
+export async function searchCollections(text: string, signal?: AbortSignal): Promise<CollectionInfo[]> {
+  const params = new URLSearchParams();
+  if (text) {
+    params.set('keyword', text);
+  }
+  const response = await fetch(
+    `${API_SERVER}/collections/api?${params.toString()}`,
+    { signal },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to search collections: ${response.status}`);
+  }
+  const result: { data: Array<{ id: number; name: string }> } = await response.json();
+  return (result.data ?? []).map(({ id, name }) => ({ id, name }));
+}
+
+export function getCollectionText(collection: CollectionInfo) {
+  return collection.name;
+}
+
+export function isCollectionEquals(a: CollectionInfo, b: CollectionInfo) {
+  return a.id === b.id;
+}


### PR DESCRIPTION
Created the missing `CollectionSelector` component that was imported but didn't exist, causing runtime errors when using collection-id parameter input.

- `CollectionSelector.tsx` — wraps `RemoteSelector` with collection-specific rendering
- `utils.ts` — search function using existing `/collections/api` endpoint
- `index.ts` — re-exports

Fixes #2496