### PR TITLE
feat: add BreadcrumbList and CollectionPage structured data to blog index

### DIFF
--- a/apps/docs/app/blog/page.tsx
+++ b/apps/docs/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { formatDisplayDate, getBlogPosts, type BlogPostSummary } from '@/lib/content';
+import { BreadcrumbListJsonLd, CollectionPageJsonLd } from '@/components/json-ld';
 
 export const metadata: Metadata = {
   title: 'Blog',
@@ -173,6 +174,16 @@ export default async function BlogIndexPage() {
 
   return (
     <div className="mx-auto w-full max-w-[1080px]">
+      <BreadcrumbListJsonLd items={[
+        { name: 'Home', url: '/' },
+        { name: 'Blog' },
+      ]} />
+      <CollectionPageJsonLd
+        title="Blog"
+        description="Helping dev teams adopt OSS technologies and practices. Written by software engineers and community analysts."
+        url="/blog"
+        posts={posts}
+      />
       <header className="mb-10 border-b border-white/[0.08] pb-8">
         <div className="text-[11px] font-medium uppercase tracking-[0.26em] text-[#fbe593]">Blog</div>
         <h1 className="mt-4 text-[30px] font-semibold leading-tight text-[#e9eaee] sm:text-[38px]">

--- a/apps/docs/components/json-ld.tsx
+++ b/apps/docs/components/json-ld.tsx
@@ -155,6 +155,44 @@ export function BreadcrumbListJsonLd({
   );
 }
 
+export function CollectionPageJsonLd({
+  title,
+  description,
+  url,
+  posts,
+}: {
+  title: string;
+  description: string;
+  url: string;
+  posts: { title: string; description: string; slug: string; date: string | null; image?: string }[];
+}) {
+  return (
+    <JsonLd
+      data={{
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: title,
+        description,
+        url: url.startsWith('http') ? url : `${SITE_URL}${url}`,
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'OSSInsight',
+          url: SITE_URL,
+        },
+        mainEntity: {
+          '@type': 'ItemList',
+          itemListElement: posts.map((post, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            url: `${SITE_URL}/blog/${post.slug}`,
+            name: post.title,
+          })),
+        },
+      }}
+    />
+  );
+}
+
 export function PersonJsonLd({
   name,
   url,


### PR DESCRIPTION
Blog post detail pages already had full JSON-LD (BlogPosting, BreadcrumbList, etc.). Added structured data to the blog index page:

- `BreadcrumbListJsonLd` — Home > Blog breadcrumb
- `CollectionPageJsonLd` — new component rendering CollectionPage schema with ItemList of all blog posts

Fixes #2418