### PR TITLE
fix: use React.cache for request deduplication in fetchOwner

### DIFF
--- a/apps/web/app/analyze/(org)/[owner]/fetchOwner.tsx
+++ b/apps/web/app/analyze/(org)/[owner]/fetchOwner.tsx
@@ -1,6 +1,8 @@
 import { getOwnerInfo } from '@/components/Analyze/utils';
 import { notFound } from 'next/navigation';
-import { cache } from 'next/cache';
+// React.cache deduplicates requests within a single render pass (RSC)
+// @ts-expect-error - React 18.2 types don't export cache, but it exists at runtime
+import { cache } from 'react';
 
 export const fetchOwnerInfo = cache(async (
   orgName: string,


### PR DESCRIPTION
Reverts the incorrect change from PR #2502. `cache` for request deduplication in React Server Components comes from `react`, not `next/cache`. Added `@ts-expect-error` since React 18.2 types don't export it but it exists at runtime.

Fixes #2519