### PR TITLE
fix: add null safety for getOrg in activity-map visualization

### DIFF
--- a/apps/web/charts/analyze/org/activity-map/visualization.ts
+++ b/apps/web/charts/analyze/org/activity-map/visualization.ts
@@ -77,8 +77,8 @@ export default function (
 ): EChartsVisualizationConfig {
   const { getOrg } = ctx;
 
-  const main = getOrg(Number(ctx.parameters.owner_id)).login;
-  const vs = getOrg(Number(ctx.parameters.owner_id)).login;
+  const main = getOrg(Number(ctx.parameters.owner_id))?.login ?? 'unknown';
+  const vs = getOrg(Number(ctx.parameters.owner_id))?.login ?? 'unknown';
 
   const { activity = 'stars' } = ctx.parameters;
   


### PR DESCRIPTION
Added optional chaining and fallback for `getOrg()` calls to prevent null pointer errors.

Fixes #2517