### PR TITLE
fix: remove unused @ts-expect-error directives

### DIFF
--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -28,7 +28,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${SITE_URL}${page.path}`,
       changeFrequency: 'weekly',
       priority: page.priority,
-      // @ts-expect-error — Next.js MetadataRoute.Sitemap doesn't type images yet
       ...(page.images ? { images: page.images } : {}),
     });
   }
@@ -42,7 +41,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         url: `${SITE_URL}/collections/${slug}`,
         changeFrequency: 'weekly',
         priority: 0.6,
-        // @ts-expect-error — Next.js MetadataRoute.Sitemap doesn't type images yet
         images: [`${SITE_URL}/collections/${slug}/opengraph-image`],
       });
       entries.push({

--- a/apps/web/charts/analyze/org/company/visualization.tsx
+++ b/apps/web/charts/analyze/org/company/visualization.tsx
@@ -1,6 +1,5 @@
 import type { WidgetVisualizerContext } from '@/lib/charts-types';
 
-// @ts-expect-error d3-cloud has no type declarations
 import cloud from 'd3-cloud';
 
 type Params = {

--- a/apps/web/charts/analyze/repo/company/visualization.tsx
+++ b/apps/web/charts/analyze/repo/company/visualization.tsx
@@ -1,6 +1,5 @@
 import type { WidgetVisualizerContext } from '@/lib/charts-types';
 // import { compare } from '@/lib/charts-utils/visualizer/analyze';
-// @ts-expect-error d3-cloud has no type declarations
 import cloud from 'd3-cloud';
 // import xss from 'xss';
 


### PR DESCRIPTION
Removed 4 unused `@ts-expect-error` directives:
- `sitemap.ts` ×2 (fixed in PR #2483)
- `org/company/visualization.tsx` (types added in PR #2484)
- `repo/company/visualization.tsx` (types added in PR #2484)

Fixes #2522