### PR TITLE
fix: resolve HTTP 500 on all collection pages

### DIFF
--- a/apps/web/app/collections/[slug]/collection-faq.tsx
+++ b/apps/web/app/collections/[slug]/collection-faq.tsx
@@ -1,36 +1,9 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import type { FAQItem } from './faq-data';
 
-export interface FAQItem {
-  question: string;
-  answer: string;
-}
-
-export function getCollectionFaqItems(collectionName: string): FAQItem[] {
-  return [
-    {
-      question: `What are the top ${collectionName} repos on GitHub?`,
-      answer: `OSSInsight tracks the most popular ${collectionName} repositories on GitHub, ranked by stars, pull requests, issues, and contributors. Visit the ranking table above to see the current top projects.`,
-    },
-    {
-      question: `How is the ${collectionName} ranking calculated?`,
-      answer: `Repositories are ranked using multiple metrics including stars, pull requests, issues, and pull request creators over the last 28 days, with month-to-month comparisons to surface trending projects.`,
-    },
-    {
-      question: `How often is ${collectionName} data updated?`,
-      answer: 'Rankings are updated in near real-time based on GitHub events processed by OSSInsight, so you always see the latest activity.',
-    },
-    {
-      question: `Can I suggest a repository for the ${collectionName} collection?`,
-      answer: 'Yes! Collection definitions are maintained in our open-source repository on GitHub. You can open a pull request to add or update repositories in any collection.',
-    },
-    {
-      question: `How can I compare ${collectionName} repositories?`,
-      answer: 'Each repository in the ranking links to a detailed analytics page where you can explore stars, commits, contributors, and more. You can also use the historical ranking chart to compare how projects have trended over time.',
-    },
-  ];
-}
+export { type FAQItem };
 
 export function CollectionFAQ({ items }: { items: FAQItem[] }) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);

--- a/apps/web/app/collections/[slug]/faq-data.ts
+++ b/apps/web/app/collections/[slug]/faq-data.ts
@@ -1,0 +1,29 @@
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+export function getCollectionFaqItems(collectionName: string): FAQItem[] {
+  return [
+    {
+      question: `What are the top ${collectionName} repos on GitHub?`,
+      answer: `OSSInsight tracks the most popular ${collectionName} repositories on GitHub, ranked by stars, pull requests, issues, and contributors. Visit the ranking table above to see the current top projects.`,
+    },
+    {
+      question: `How is the ${collectionName} ranking calculated?`,
+      answer: `Repositories are ranked using multiple metrics including stars, pull requests, issues, and pull request creators over the last 28 days, with month-to-month comparisons to surface trending projects.`,
+    },
+    {
+      question: `How often is ${collectionName} data updated?`,
+      answer: 'Rankings are updated in near real-time based on GitHub events processed by OSSInsight, so you always see the latest activity.',
+    },
+    {
+      question: `Can I suggest a repository for the ${collectionName} collection?`,
+      answer: 'Yes! Collection definitions are maintained in our open-source repository on GitHub. You can open a pull request to add or update repositories in any collection.',
+    },
+    {
+      question: `How can I compare ${collectionName} repositories?`,
+      answer: 'Each repository in the ranking links to a detailed analytics page where you can explore stars, commits, contributors, and more. You can also use the historical ranking chart to compare how projects have trended over time.',
+    },
+  ];
+}

--- a/apps/web/app/collections/[slug]/page.tsx
+++ b/apps/web/app/collections/[slug]/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { CollectionDetail } from './content';
 import { AggregateRatingJsonLd, BreadcrumbListJsonLd, CollectionPageJsonLd, FAQPageJsonLd } from '@/components/json-ld';
-import { getCollectionFaqItems } from './collection-faq';
+import { getCollectionFaqItems } from './faq-data';
 
 export const revalidate = 3600;
 


### PR DESCRIPTION
## Critical Fix

All collection slug pages (`/collections/[slug]`) were returning HTTP 500.

### Root Cause
`getCollectionFaqItems` was defined in `collection-faq.tsx` which has `'use client'` directive. Importing and calling this function from the server component `page.tsx` caused a runtime error in Next.js.

### Fix
Split into two files:
- `faq-data.ts` — pure data function (server-safe), used by `page.tsx`
- `collection-faq.tsx` — client component only, re-exports the type

Fixes #2532