### PR TITLE
Add new iflytek tools to collections

### DIFF
--- a/configs/collections/10076.llm-tools.yml
+++ b/configs/collections/10076.llm-tools.yml
@@ -26,4 +26,5 @@ items:
   - VoltAgent/voltagent
   - iflytek/astron-agent
   - iflytek/astron-rpa
+  - iflytek/astronclaw-tutorial
   - Fast-Editor/Lynkr

--- a/configs/collections/10124.agent-skills.yml
+++ b/configs/collections/10124.agent-skills.yml
@@ -11,3 +11,5 @@ items:
   - Agenta-AI/agenta
   - guidance-ai/guidance
   - 567-labs/instructor
+  - iflytek/skillhub
+  - iflytek/iFly-Skills


### PR DESCRIPTION
**What problem does this PR solve?**

Some popular AI tools from iFlytek are missing in the collections.
Issue Number: close #2896

**Problem Summary:**
The current collections are missing `iflytek/skillhub`, `iflytek/astronclaw-tutorial`, and `iflytek/iFly-Skills`. Adding these repositories ensures the collection remains up-to-date and comprehensive for users interested in AI agent tools.

**What is changed and how it works?**

- Added `iflytek/astronclaw-tutorial` to the `llm-tools` collection.
- Added `iflytek/skillhub` and `iflytek/iFly-Skills` to the `agent-skills` collection.