### PR TITLE
config: add wandb, promptflow, langsmith-sdk to AI Observability collection

### DIFF
--- a/configs/collections/10135.ai-observability.yml
+++ b/configs/collections/10135.ai-observability.yml
@@ -13,3 +13,6 @@ items:
   - uptrain-ai/uptrain
   - whylabs/whylogs
   - zenml-io/zenml
+  - wandb/wandb
+  - microsoft/promptflow
+  - langchain-ai/langsmith-sdk


### PR DESCRIPTION
## Summary
Expands the AI Observability collection (10135) with three widely-used LLM/agent monitoring tools that were missing.

## Context
Refs #3022. The collection already existed but was missing high-signal tools cited in the issue: Weights & Biases (11k stars), Microsoft PromptFlow (11k stars), and LangSmith SDK (the official tracing SDK for LangChain agent workflows).

## Changes
- Added `wandb/wandb` to 10135.ai-observability.yml
- Added `microsoft/promptflow` to 10135.ai-observability.yml
- Added `langchain-ai/langsmith-sdk` to 10135.ai-observability.yml

## Testing
- All three repos verified via GitHub API: active, non-archived
- Cross-listing across collections is established practice in this repo