### PR TITLE
config: add caura-ai/caura-memclaw to ai-agent-memory collection

### DIFF
--- a/configs/collections/10114.ai-agent-memory.yml
+++ b/configs/collections/10114.ai-agent-memory.yml
@@ -9,3 +9,4 @@ items:
   - memvid/memvid
   - getzep/zep-python
   - pingcap/tidb
+  - caura-ai/caura-memclaw


### PR DESCRIPTION
Add caura-ai/caura-memclaw to the AI Agent Memory collection.

MemClaw is an open-source governed shared memory platform for AI agents and agent fleets, providing persistent memory, cross-agent knowledge sharing, permissions, audit trails, and multi-tenant isolation.