### PR TITLE
docs: remove broken OSS Insight Lite demo link

### DIFF
--- a/apps/docs/legacy-content/docs/workshop/ossinsight-lite/introduction.md
+++ b/apps/docs/legacy-content/docs/workshop/ossinsight-lite/introduction.md
@@ -11,8 +11,6 @@ By joining this workshop, you can get:
 1. A free MySQL-Compatible serverless database with analytical capability
 2. A well-designed personal/repos GitHub activities analysis tool
 
-Live Demo: http://ossinsight-lite.vercel.app/
-
 
 ## Requirements
 


### PR DESCRIPTION
Closes #2764.

## Summary
- Remove the OSS Insight Lite live demo link from the legacy workshop introduction because the Vercel deployment currently returns `DEPLOYMENT_NOT_FOUND`.

## Verification
- `curl -L -I -s --max-time 10 http://ossinsight-lite.vercel.app/` returns Vercel `DEPLOYMENT_NOT_FOUND` after redirecting to HTTPS
- `curl -L -I -s --max-time 10 https://ossinsight-lite.vercel.app/` returns Vercel `DEPLOYMENT_NOT_FOUND`
- Checked the updated file no longer contains `Live Demo` or `ossinsight-lite.vercel.app`