### PR TITLE
web: put Data Explorer into maintenance mode

### DIFF
--- a/apps/web/app/api/explorer/ask/route.ts
+++ b/apps/web/app/api/explorer/ask/route.ts
@@ -6,7 +6,6 @@ import { normalizeExplorerChart, inferExplorerFields } from "@/lib/explorer/char
 import { explorerChartKinds, type ExplorerAnswer } from "@/lib/explorer/contracts";
 import { buildExplorerPlanningPrompt } from "@/lib/explorer/prompt";
 import { executeExplorerRows, explainExplorerRows } from "@/lib/explorer/query";
-import { explorerRateLimit } from "@/lib/rate-limit";
 
 export const runtime = "edge";
 export const maxDuration = 30;
@@ -15,6 +14,16 @@ const requestSchema = z.object({
   question: z.string().trim().min(4).max(400),
   stream: z.boolean().optional(),
 });
+
+const maintenanceResponse = {
+  error: "Data Explorer is under maintenance.",
+  code: "EXPLORER_UNDER_MAINTENANCE",
+  message: "Data Explorer 正在维护中，暂时不可用。",
+};
+
+function isExplorerUnderMaintenance() {
+  return true;
+}
 
 const chartSchema = z.object({
   kind: z.enum(explorerChartKinds),
@@ -45,11 +54,21 @@ const openai = createOpenAI({
 });
 
 export async function POST(request: Request) {
+  if (isExplorerUnderMaintenance()) {
+    return Response.json(maintenanceResponse, {
+      status: 503,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
   const ip =
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
     request.headers.get("x-real-ip") ??
     "unknown";
 
+  const { explorerRateLimit } = await import("@/lib/rate-limit");
   const { success, remaining, reset } = await explorerRateLimit.limit(ip);
   if (!success) {
     const retryAfterSeconds = Math.max(1, Math.ceil((reset - Date.now()) / 1000));

--- a/apps/web/app/explore/maintenance.tsx
+++ b/apps/web/app/explore/maintenance.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import { ArrowLeft, BarChart3, Clock3, Wrench } from 'lucide-react';
+
+export function ExploreMaintenance() {
+  return (
+    <main className="min-h-[calc(100vh-var(--site-header-height))] bg-[#1a1a1b] text-white">
+      <section className="mx-auto flex min-h-[calc(100vh-var(--site-header-height))] w-full max-w-5xl flex-col justify-center px-6 py-16 sm:px-10">
+        <div className="max-w-2xl">
+          <div className="mb-8 inline-flex h-12 w-12 items-center justify-center rounded-lg border border-white/10 bg-[#242526] text-[#FFE895]">
+            <Wrench className="h-6 w-6" aria-hidden="true" />
+          </div>
+
+          <p className="mb-4 flex items-center gap-2 text-sm font-medium uppercase tracking-[0.18em] text-[#FFE895]">
+            <Clock3 className="h-4 w-4" aria-hidden="true" />
+            维护中
+          </p>
+
+          <h1 className="text-4xl font-semibold leading-tight text-[#f4f4f5] sm:text-5xl">
+            Data Explorer 正在维护中
+          </h1>
+
+          <p className="mt-6 text-lg leading-8 text-[#c8c8c8]">
+            Explore 功能正在更新，暂时不可用。你仍然可以查看仓库分析、
+            Collections 和 Trending 页面。
+          </p>
+
+          <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/"
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-white/10 bg-[#FFE895] px-5 text-sm font-semibold text-[#1f1e28] transition hover:bg-white"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              返回首页
+            </Link>
+            <Link
+              href="/trending"
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-white/10 bg-[#242526] px-5 text-sm font-semibold text-[#f4f4f5] transition hover:border-white/20 hover:bg-[#2c2d2f]"
+            >
+              <BarChart3 className="h-4 w-4" aria-hidden="true" />
+              查看 Trending
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -1,19 +1,17 @@
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
-import { BreadcrumbListJsonLd, DatasetJsonLd } from '@/components/json-ld';
-import { ExploreContent } from './content';
-import ShareButtons from '@/components/ShareButtons';
+import { BreadcrumbListJsonLd } from '@/components/json-ld';
+import { ExploreMaintenance } from './maintenance';
 
 export const metadata: Metadata = {
-  title: 'GitHub Data Explorer',
-  description: 'Discover insights in GitHub event data with AI-generated SQL and preset visualizations.',
+  title: 'Data Explorer 维护中',
+  description: 'OSSInsight Data Explorer 正在维护中，暂时不可用。',
   openGraph: {
-    title: 'GitHub Data Explorer | OSSInsight',
-    description: 'Discover insights in GitHub event data with AI-generated SQL and preset visualizations.',
+    title: 'Data Explorer 维护中 | OSSInsight',
+    description: 'OSSInsight Data Explorer 正在维护中，暂时不可用。',
   },
   twitter: {
-    title: 'GitHub Data Explorer | OSSInsight',
-    description: 'Discover insights in GitHub event data with AI-generated SQL and preset visualizations.',
+    title: 'Data Explorer 维护中 | OSSInsight',
+    description: 'OSSInsight Data Explorer 正在维护中，暂时不可用。',
     card: 'summary_large_image',
   },
   alternates: { canonical: '/explore' },
@@ -26,23 +24,7 @@ export default function ExplorePage() {
         { name: 'Home', url: '/' },
         { name: 'Data Explorer' },
       ]} />
-      <DatasetJsonLd
-        name="GitHub Open Source Event Data"
-        description="Over 10 billion GitHub events from 2011 to present, including stars, forks, pull requests, issues, commits, and contributor activity for millions of open source repositories."
-        url="https://ossinsight.io/explore"
-      />
-      <div className="sr-only">
-        <h1>GitHub Data Explorer</h1>
-        <p>
-          Discover insights in GitHub event data with AI-generated SQL. Ask questions in plain English
-          about GitHub repositories, developers, and trends — OSSInsight generates and runs SQL queries
-          against over 10 billion GitHub events and returns interactive visualizations.
-        </p>
-      </div>
-      <Suspense>
-        <ExploreContent />
-      </Suspense>
-      <ShareButtons url="/explore" title="GitHub Data Explorer — OSSInsight" />
+      <ExploreMaintenance />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Replace `/explore` with a simple maintenance page while leaving the previous Explore implementation intact.
- Update `/explore` metadata to reflect maintenance status.
- Short-circuit `POST /api/explorer/ask` with `503 EXPLORER_UNDER_MAINTENANCE` before rate limiting, OpenAI text2sql, or SQL execution can run.

## Test Plan
- `git diff --check`
- `curl http://localhost:3011/explore` returns 200 and includes `Data Explorer 正在维护中`
- `curl -X POST http://localhost:3011/api/explorer/ask ...` returns 503 with `EXPLORER_UNDER_MAINTENANCE`

## Notes
- `pnpm --filter web check-types` still fails on existing chart/data-service/site-shell type errors unrelated to this change.