### PR TITLE
web: force dynamic rendering for analyze routes

### DIFF
--- a/apps/web/app/analyze/(org)/[owner]/page.tsx
+++ b/apps/web/app/analyze/(org)/[owner]/page.tsx
@@ -7,6 +7,7 @@ import { BreadcrumbListJsonLd } from '@/components/json-ld';
 import ShareButtons from '@/components/ShareButtons';
 import { Metadata } from 'next';
 
+export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
 
 export async function generateStaticParams() {

--- a/apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx
+++ b/apps/web/app/analyze/(repo)/[owner]/[repo]/page.tsx
@@ -4,6 +4,7 @@ import { getRepoByName } from '@/lib/server/internal-api';
 import { BreadcrumbListJsonLd, SoftwareApplicationJsonLd, SoftwareSourceCodeJsonLd } from '@/components/json-ld';
 import RepoAnalyzePage from './content';
 
+export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
 
 export async function generateStaticParams() {


### PR DESCRIPTION
## Summary
- Mark `/analyze/[owner]` as `force-dynamic` so fallback owner pages do not switch from static to dynamic at runtime.
- Apply the same route segment config to `/analyze/[owner]/[repo]`, which also reads live TiDB-backed repository data during server rendering and metadata generation.

## Why
Next.js throws `app/ Static to Dynamic Error` when a route is initially treated as static and later uses runtime dynamic data such as a `revalidate: 0` fetch. The analyze pages depend on live TiDB data, so they should consistently render dynamically.

## Test Plan
- `git diff --check`
- `pnpm --filter web build`
  - Build succeeds.
  - Output marks `/analyze/[owner]` and `/analyze/[owner]/[repo]` as dynamic (`ƒ`).

## Notes
- Build still logs an existing homepage dynamic fetch warning for `/`; that is unrelated to this change and does not fail the build.