### PR TITLE
web: validate runtime URLs

### DIFF
--- a/apps/web/lib/data-service/connection.ts
+++ b/apps/web/lib/data-service/connection.ts
@@ -1,12 +1,39 @@
 import { connect } from '@tidbcloud/serverless';
 
+let cachedTiDBConnection: ReturnType<typeof connect> | undefined;
+
 export function getOssInsightDatabase() {
   return process.env.OSSINSIGHT_DATABASE || 'gharchive_dev';
 }
 
+export function getDatabaseUrl() {
+  const url = process.env.DATABASE_URL?.trim();
+  if (!url) {
+    throw new Error('Missing DATABASE_URL for OSSInsight TiDB connection.');
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (!parsed.hostname) {
+      throw new TypeError('DATABASE_URL must include a host.');
+    }
+  } catch {
+    throw new Error('Invalid DATABASE_URL for OSSInsight TiDB connection.');
+  }
+
+  return url;
+}
+
+export function getTiDBConnection() {
+  if (!cachedTiDBConnection) {
+    cachedTiDBConnection = createTiDBConnection();
+  }
+  return cachedTiDBConnection;
+}
+
 export function createTiDBConnection() {
   return connect({
-    url: process.env.DATABASE_URL,
+    url: getDatabaseUrl(),
     database: getOssInsightDatabase(),
   });
 }

--- a/apps/web/lib/data-service/executor/server.ts
+++ b/apps/web/lib/data-service/executor/server.ts
@@ -2,10 +2,8 @@ import { FullResult } from '@tidbcloud/serverless';
 import { Liquid } from 'liquidjs';
 import { DateTime } from 'luxon';
 import { EndpointConfig } from '../config';
-import { createTiDBConnection } from '../connection';
+import { getTiDBConnection } from '../connection';
 import { applyLegacyQueryParameters, BIG_NUMBER_TYPES, prepareQueryContext } from './utils';
-
-const tidb = createTiDBConnection();
 
 const templateEngine = new Liquid();
 
@@ -17,6 +15,7 @@ export default async function executeEndpoint (name: string, config: EndpointCon
   // ARCHITECTURAL NOTE: SQL is built via string replacement (applyLegacyQueryParameters)
   // rather than parameterized queries. Safety relies on prepareQueryContext validation
   // (pattern/enum checks) and stringifyParamValue quote-escaping for STRING types.
+  const tidb = getTiDBConnection();
   const start = DateTime.now();
   const result = await tidb.execute(sql, null, {
     fullResult: true,

--- a/apps/web/lib/data-service/query.ts
+++ b/apps/web/lib/data-service/query.ts
@@ -1,8 +1,6 @@
 import type { ExecuteArgs, FullResult } from '@tidbcloud/serverless';
 import { BIG_NUMBER_TYPES } from './executor/utils';
-import { createTiDBConnection } from './connection';
-
-const tidb = createTiDBConnection();
+import { getTiDBConnection } from './connection';
 
 export type QueryRows = Record<string, any>[];
 
@@ -11,6 +9,7 @@ export async function executeSQL(
   args: ExecuteArgs = null,
   signal?: AbortSignal,
 ) {
+  const tidb = getTiDBConnection();
   const result = await tidb.execute(statement, args, {
     fullResult: true,
   }) as FullResult;

--- a/apps/web/utils/api.ts
+++ b/apps/web/utils/api.ts
@@ -8,23 +8,53 @@ export const EXPLORER_API_SERVER = process.env.NEXT_PUBLIC_EXPLORER_API_SERVER |
 export const API_SERVER = typeof window === 'undefined' ? getSiteOrigin() : '';
 export const INTERNAL_API_SERVER = `${API_SERVER}/api`;
 export const INTERNAL_QUERY_API_SERVER = `${INTERNAL_API_SERVER}/q`;
-export const SITE_HOST = process.env.NEXT_PUBLIC_SITE_HOST || (typeof window === 'undefined' ? getSiteOrigin() : window.location.origin);
+export const SITE_HOST = typeof window === 'undefined'
+  ? getSiteOrigin()
+  : normalizeOrigin(process.env.NEXT_PUBLIC_SITE_HOST) ?? window.location.origin;
 
 export function getSiteOrigin() {
-  const explicitHost = process.env.NEXT_PUBLIC_SITE_HOST;
+  const explicitHost = normalizeOrigin(process.env.NEXT_PUBLIC_SITE_HOST);
   if (explicitHost) {
-    return explicitHost.replace(/\/$/, '');
+    return explicitHost;
   }
 
   const previewHost =
     process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
     process.env.VERCEL_BRANCH_URL ||
     process.env.VERCEL_URL;
-  if (previewHost) {
-    return `https://${previewHost}`;
+  const previewOrigin = normalizeOrigin(previewHost);
+  if (previewOrigin) {
+    return previewOrigin;
   }
 
   return `http://127.0.0.1:${process.env.PORT || 3001}`;
+}
+
+export function normalizeOrigin(origin?: string | null) {
+  const trimmed = origin?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const candidate = /^https?:\/\//i.test(trimmed)
+    ? trimmed
+    : `${isLocalOrigin(trimmed) ? 'http' : 'https'}://${trimmed}`;
+
+  try {
+    return new URL(candidate).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isLocalOrigin(origin: string) {
+  const host = origin
+    .replace(/^https?:\/\//i, '')
+    .replace(/^\[([^\]]+)\].*$/, '$1')
+    .split('/')[0]
+    .split(':')[0];
+
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1';
 }
 
 export function rewriteInternalApiUrl(url: string) {


### PR DESCRIPTION
## Summary
- normalize site origins before using them to build server-side internal API URLs
- validate DATABASE_URL before creating the TiDB serverless connection
- lazily create the TiDB connection when a query executes, so config errors are reported at the query boundary

## Testing
- pnpm --filter web build

Note: local build logs `Missing DATABASE_URL for OSSInsight TiDB connection.` from the existing homepage treemap fallback because local env does not include DATABASE_URL; the build still succeeds.