### PR TITLE
web: fix recommended user mappings

### DIFF
--- a/apps/web/lib/github-search/recommend/users-list.json
+++ b/apps/web/lib/github-search/recommend/users-list.json
@@ -1,8 +1,8 @@
 [
-  {"id": 13171097, "login": "hwchase17"},
-  {"id": 1991296, "login": "jmorgan"},
+  {"id": 11986836, "login": "hwchase17"},
+  {"id": 1991296, "login": "ggerganov"},
   {"id": 6916170, "login": "segunadebayo"},
-  {"id": 41080, "login": "karpathy"},
+  {"id": 241138, "login": "karpathy"},
   {"id": 56883, "login": "Swizec"},
   {"id": 4921183, "login": "kamranahmedse"},
   {"id": 8255800, "login": "521xueweihan"},


### PR DESCRIPTION
Update recommended user id/login pairs so the selector routes to users with matching OSSInsight data. Checked every entry against /gh/user/{id}; all recommended users now match their configured login.