### PR TITLE
config: add supernovae-st/nika to Workflow Scheduler collection

### DIFF
--- a/configs/collections/10057.workflow-scheduler.yml
+++ b/configs/collections/10057.workflow-scheduler.yml
@@ -10,3 +10,4 @@ items:
   - temporalio/temporal
   - PowerJob/PowerJob
   - PrefectHQ/prefect
+  - supernovae-st/nika


### PR DESCRIPTION
Adds [nika](https://github.com/supernovae-st/nika) to the Workflow Scheduler collection (10057).

nika is a workflow runner for AI jobs: the job lives in one plain-text `.nika.yaml` DAG, statically checked before anything runs (plan, types, secret flows, cost floor), executed by a single Rust binary with hash-chained run traces. It sits beside the schedulers already in this collection — Airflow/Temporal/Prefect orchestrate infra and services; nika is the reviewable file for the AI-native slice (runs fine inside any of them, incl. a GitHub Action).

Full disclosure: I'm the author. AGPL-3.0 engine, Apache-2.0 spec, actively developed (latest release 0.99.0, 2026-07-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)