### PR TITLE
config: add AI Coding Agent Design Tool collection

### DIFF
--- a/configs/collections/10142.ai-coding-agent-design-tool.yml
+++ b/configs/collections/10142.ai-coding-agent-design-tool.yml
@@ -1,0 +1,11 @@
+id: 10142
+name: AI Coding Agent Design Tool
+items:
+  - anthropics/skills
+  - Leonxlnx/taste-skill
+  - superdesigndev/superdesign
+  - ZSeven-W/openpencil
+  - JimLiu/baoyu-design
+  - dominikmartn/nothing-design-skill
+  - dominikmartn/hue
+  - bitjaru/styleseed


### PR DESCRIPTION
Adds a new collection: **AI Coding Agent Design Tool** — the fast-growing category of tools/skills that make AI coding agents (Claude Code, Cursor, Codex) produce better-designed, less generic UI.

8 repos, all active and verified:
| Repo | Stars | What it is |
|---|---|---|
| anthropics/skills | 161k | Official skills incl. `frontend-design` |
| Leonxlnx/taste-skill | 64k | Taste/design skill suite |
| superdesigndev/superdesign | 6.7k | Open-source design agent |
| ZSeven-W/openpencil | 4.1k | Design tool for agents |
| JimLiu/baoyu-design | 2.6k | Design skill |
| dominikmartn/nothing-design-skill | 2.6k | Design skill |
| dominikmartn/hue | 0.8k | Color/design tool |
| bitjaru/styleseed | 0.8k | Design-rules engine + scored quality gate (disclosure: my project) |

Category rationale: this niche exploded in the last 6 months (taste-skill 0→64k stars) and has no existing collection; `10001.css-framework.yml` style followed. Next free id used (10142). Happy to adjust the item list per your curation standards.