### PR TITLE
Add whatbroke to AI Evaluation & Testing collection

### DIFF
--- a/configs/collections/10119.ai-evaluation-testing.yml
+++ b/configs/collections/10119.ai-evaluation-testing.yml
@@ -13,3 +13,4 @@ items:
   - Agenta-AI/agenta
   - NVIDIA/garak
   - anthropics/evals
+  - arthi-arumugam-git/whatbroke


### PR DESCRIPTION
Adding [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) to the AI Evaluation & Testing collection.

It's a CLI that diffs an LLM agent's recorded behavior (tool calls, arguments, latency) between two runs: e.g. before/after a model swap or prompt change, and reports what changed at the tool-call level, with multi-sample rates to separate real regressions from baseline flakiness. MIT, on npm as whatbroke-cli, fully offline.

It sits in the same lane as promptfoo/deepeval but answers "what changed between these two versions" rather than scoring against a rubric.

Thanks for maintaining these collections!
