### PR TITLE
feat(web): add configurable MiniMax provider for Data Explorer

### DIFF
--- a/apps/web/app/api/explorer/ask/route.ts
+++ b/apps/web/app/api/explorer/ask/route.ts
@@ -6,6 +6,7 @@ import { normalizeExplorerChart, inferExplorerFields } from "@/lib/explorer/char
 import { explorerChartKinds, type ExplorerAnswer } from "@/lib/explorer/contracts";
 import { buildExplorerPlanningPrompt } from "@/lib/explorer/prompt";
 import { executeExplorerRows, explainExplorerRows } from "@/lib/explorer/query";
+import { createMinimaxModel, readMinimaxConfig } from "@/lib/explorer/provider";
 
 export const runtime = "edge";
 export const maxDuration = 30;
@@ -53,6 +54,24 @@ const openai = createOpenAI({
   apiKey: openaiApiKey,
 });
 
+const minimaxConfig = readMinimaxConfig();
+
+function resolveExplorerModel() {
+  if (minimaxConfig) {
+    return createMinimaxModel(minimaxConfig);
+  }
+  return openai("gpt-5.2");
+}
+
+const explorerProviderOptions = minimaxConfig
+  ? undefined
+  : {
+      openai: {
+        reasoningEffort: "low" as const,
+        textVerbosity: "low" as const,
+      },
+    };
+
 export async function POST(request: Request) {
   if (isExplorerUnderMaintenance()) {
     return Response.json(maintenanceResponse, {
@@ -90,7 +109,7 @@ export async function POST(request: Request) {
   try {
     const body = requestSchema.parse(await request.json());
 
-    if (!openaiApiKey) {
+    if (!minimaxConfig && !openaiApiKey) {
       return Response.json(
         { error: "Missing OPENAI_API_TOKEN (or OPENAI_API_KEY) for Data Explorer." },
         { status: 500, headers: { "Cache-Control": "no-store" } },
@@ -125,18 +144,13 @@ export async function POST(request: Request) {
 
 async function generateExplorerPlan(question: string) {
   const { object: plan } = await generateObject({
-    model: openai("gpt-5.2"),
+    model: resolveExplorerModel(),
     schemaName: "ExplorerPlan",
     schemaDescription:
       "A safe readonly SQL plan and chart plan for OSSInsight Data Explorer.",
     schema: planSchema,
     prompt: buildExplorerPlanningPrompt(question),
-    providerOptions: {
-      openai: {
-        reasoningEffort: "low",
-        textVerbosity: "low",
-      },
-    },
+    providerOptions: explorerProviderOptions,
   });
 
   return plan;
@@ -201,18 +215,13 @@ function streamExplorerAnswer(question: string, startedAt: number) {
           send({ type: "phase", phase: "generating" });
 
           const result = streamObject({
-            model: openai("gpt-5.2"),
+            model: resolveExplorerModel(),
             schemaName: "ExplorerPlan",
             schemaDescription:
               "A safe readonly SQL plan and chart plan for OSSInsight Data Explorer.",
             schema: planSchema,
             prompt: buildExplorerPlanningPrompt(question),
-            providerOptions: {
-              openai: {
-                reasoningEffort: "low",
-                textVerbosity: "low",
-              },
-            },
+            providerOptions: explorerProviderOptions,
           });
 
           let lastPreview = "";

--- a/apps/web/lib/explorer/provider.ts
+++ b/apps/web/lib/explorer/provider.ts
@@ -1,0 +1,83 @@
+import { createOpenAI } from "@ai-sdk/openai";
+
+// Regional base URLs for the MiniMax OpenAI-compatible chat API. The Data
+// Explorer can be pointed at either the global endpoint or the mainland-China
+// endpoint through the MINIMAX_API_REGION environment variable.
+export const MINIMAX_REGION_BASE_URLS = {
+  global_en: "https://api.minimax.io/v1",
+  cn_zh: "https://api.minimaxi.com/v1",
+} as const;
+
+export type MinimaxRegion = keyof typeof MINIMAX_REGION_BASE_URLS;
+
+export const MINIMAX_DEFAULT_REGION: MinimaxRegion = "global_en";
+
+// Supported MiniMax text models and their context windows (in tokens).
+export const MINIMAX_MODELS = {
+  "MiniMax-M3": { contextWindow: 1_000_000 },
+  "MiniMax-M2.7": { contextWindow: 204_800 },
+} as const;
+
+export type MinimaxModelId = keyof typeof MINIMAX_MODELS;
+
+export const MINIMAX_DEFAULT_MODEL: MinimaxModelId = "MiniMax-M3";
+
+export function resolveMinimaxRegion(
+  value: string | undefined,
+): MinimaxRegion {
+  return value && value in MINIMAX_REGION_BASE_URLS
+    ? (value as MinimaxRegion)
+    : MINIMAX_DEFAULT_REGION;
+}
+
+export function resolveMinimaxModel(
+  value: string | undefined,
+): MinimaxModelId {
+  return value && value in MINIMAX_MODELS
+    ? (value as MinimaxModelId)
+    : MINIMAX_DEFAULT_MODEL;
+}
+
+export function resolveMinimaxBaseUrl(
+  region: MinimaxRegion,
+  override: string | undefined,
+): string {
+  const url = override?.trim() || MINIMAX_REGION_BASE_URLS[region];
+  return url.replace(/\/+$/, "");
+}
+
+export interface MinimaxConfig {
+  apiKey: string;
+  region: MinimaxRegion;
+  baseURL: string;
+  modelId: MinimaxModelId;
+}
+
+// Read the MiniMax configuration from the environment. Returns null when no
+// MiniMax API key is configured, so callers can keep their existing default
+// provider behaviour untouched.
+export function readMinimaxConfig(
+  env: Record<string, string | undefined> = process.env,
+): MinimaxConfig | null {
+  const apiKey = env.MINIMAX_API_KEY?.trim();
+  if (!apiKey) {
+    return null;
+  }
+
+  const region = resolveMinimaxRegion(env.MINIMAX_API_REGION);
+  return {
+    apiKey,
+    region,
+    baseURL: resolveMinimaxBaseUrl(region, env.MINIMAX_API_BASE_URL),
+    modelId: resolveMinimaxModel(env.MINIMAX_MODEL),
+  };
+}
+
+// Build a language model bound to the MiniMax OpenAI-compatible endpoint.
+export function createMinimaxModel(config: MinimaxConfig) {
+  const provider = createOpenAI({
+    apiKey: config.apiKey,
+    baseURL: config.baseURL,
+  });
+  return provider(config.modelId);
+}

--- a/apps/web/lib/explorer/provider.ts
+++ b/apps/web/lib/explorer/provider.ts
@@ -76,8 +76,9 @@ export function readMinimaxConfig(
 // Build a language model bound to the MiniMax OpenAI-compatible endpoint.
 export function createMinimaxModel(config: MinimaxConfig) {
   const provider = createOpenAI({
+    name: "minimax",
     apiKey: config.apiKey,
     baseURL: config.baseURL,
   });
-  return provider(config.modelId);
+  return provider.chat(config.modelId);
 }


### PR DESCRIPTION
Reason: The Data Explorer route had no configurable provider or base-URL layer, so it could not target the MiniMax global or China endpoints or its current models.

## What changed
- Add `apps/web/lib/explorer/provider.ts`, a small MiniMax provider layer that:
  - maps the `global_en` and `cn_zh` regions to their OpenAI-compatible base URLs (`https://api.minimax.io/v1` and `https://api.minimaxi.com/v1`);
  - registers the current MiniMax text models `MiniMax-M3` (1,000,000-token context) and `MiniMax-M2.7` (204,800-token context), defaulting to `MiniMax-M3`;
  - reads `MINIMAX_API_KEY`, `MINIMAX_API_REGION`, `MINIMAX_API_BASE_URL` and `MINIMAX_MODEL` from the environment and builds a language model bound to the resolved endpoint.
- Wire `apps/web/app/api/explorer/ask/route.ts` to use the MiniMax model when `MINIMAX_API_KEY` is configured, and to keep the existing default provider otherwise. The reasoning provider options are only sent on the default path so they are not forwarded to the MiniMax endpoint.

## Configuration
- `MINIMAX_API_KEY` — API key; enables the MiniMax provider when set.
- `MINIMAX_API_REGION` — `global_en` (default) or `cn_zh`.
- `MINIMAX_MODEL` — `MiniMax-M3` (default) or `MiniMax-M2.7`.
- `MINIMAX_API_BASE_URL` — optional base-URL override.

## Checks
- `tsc --noEmit` in `apps/web`: the changed files (`app/api/explorer/ask/route.ts`, `lib/explorer/provider.ts`) add no new type errors relative to the repository's pre-existing baseline.
