### PR TITLE
config: add k-horikawa-dale/auto-report-creator to Agent Skills & AGENTS.md collection

### DIFF
--- a/configs/collections/10124.agent-skills.yml
+++ b/configs/collections/10124.agent-skills.yml
@@ -13,3 +13,4 @@ items:
   - 567-labs/instructor
   - iflytek/skillhub
   - iflytek/iFly-Skills
+  - k-horikawa-dale/auto-report-creator


### PR DESCRIPTION
Adds one repository to the existing `10124.agent-skills.yml` collection.

### Repository

[k-horikawa-dale/auto-report-creator](https://github.com/k-horikawa-dale/auto-report-creator) — turns chat transcripts (ChatGPT/Claude exports, JSON, JSONL, or labeled text) into structured reports: executive briefs, technical write-ups, meeting minutes, changelogs, FAQs, or short digests, as Markdown, HTML or JSON.

### Why it fits this collection

It ships as an agent skill (`SKILL.md` plus bundled scripts and references) designed to be dropped into an agent's skills directory, which is what this collection tracks. It also works standalone as a CLI.

Two properties that distinguish it from general summarization tools:

- **Extractive by design.** Every sentence in a generated report is copied verbatim from the source transcript and carries a `^[message N]` citation. Nothing is paraphrased or invented, and a test enforces this rather than leaving it as a documented promise.
- **Secret redaction runs before analysis**, so API keys pasted mid-debug cannot reach a shared report. False positives are handled (Luhn check for card numbers, allowlists for localhost and `example.com`).

Zero third-party dependencies, standard library only, Python 3.9+. English and Japanese output with automatic language detection.

### Verification

- Repository is public and resolves with HTTP 200 from the GitHub API
- Name matches the required `owner/repo` format, no duplicate entry in the collection
- Collection file parses with the same logic as `scripts/verify-collection.mjs` (id and name unchanged, 13 unique items)
- CI on the added repository is green across Linux, macOS and Windows on Python 3.9–3.13

Happy to move this to a different collection or close the PR if it is not a fit.
