### PR TITLE
config: add open-multi-agent to AI Agent Frameworks collection

### DIFF
--- a/configs/collections/10098.ai-agent-frameworks.yml
+++ b/configs/collections/10098.ai-agent-frameworks.yml
@@ -18,3 +18,4 @@ items:
   - ag2ai/ag2
   - omega-memory/omega-memory
   - mastra-ai/mastra
+  - open-multi-agent/open-multi-agent


### PR DESCRIPTION
## What changed

Add `open-multi-agent/open-multi-agent` to the existing AI Agent Frameworks collection.

Open Multi-Agent is an open-source, TypeScript-native framework for controlled and inspectable multi-agent orchestration. This PR changes only the collection's repository list.

## Validation

- The collection contains 18 valid, unique repository IDs, with Open Multi-Agent appearing exactly once.
- The canonical repository is public and not archived.
- `git diff --check`
- The full `verify-collection.mjs` scan is currently blocked by 175 pre-existing errors on the unchanged upstream baseline; none refers to Open Multi-Agent.

Disclosure: I maintain Open Multi-Agent.
