### PR TITLE
web: translate Data Explorer maintenance page to English

### DIFF
--- a/apps/web/app/api/explorer/ask/route.ts
+++ b/apps/web/app/api/explorer/ask/route.ts
@@ -18,7 +18,7 @@ const requestSchema = z.object({
 const maintenanceResponse = {
   error: "Data Explorer is under maintenance.",
   code: "EXPLORER_UNDER_MAINTENANCE",
-  message: "Data Explorer 正在维护中，暂时不可用。",
+  message: "Data Explorer is under maintenance and temporarily unavailable.",
 };
 
 function isExplorerUnderMaintenance() {

--- a/apps/web/app/explore/maintenance.tsx
+++ b/apps/web/app/explore/maintenance.tsx
@@ -12,16 +12,16 @@ export function ExploreMaintenance() {
 
           <p className="mb-4 flex items-center gap-2 text-sm font-medium uppercase tracking-[0.18em] text-[#FFE895]">
             <Clock3 className="h-4 w-4" aria-hidden="true" />
-            维护中
+            Under maintenance
           </p>
 
           <h1 className="text-4xl font-semibold leading-tight text-[#f4f4f5] sm:text-5xl">
-            Data Explorer 正在维护中
+            Data Explorer is under maintenance
           </h1>
 
           <p className="mt-6 text-lg leading-8 text-[#c8c8c8]">
-            Explore 功能正在更新，暂时不可用。你仍然可以查看仓库分析、
-            Collections 和 Trending 页面。
+            Explore is being updated and is temporarily unavailable. You can still browse
+            repository analytics, Collections, and Trending pages.
           </p>
 
           <div className="mt-10 flex flex-col gap-3 sm:flex-row">
@@ -30,14 +30,14 @@ export function ExploreMaintenance() {
               className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-white/10 bg-[#FFE895] px-5 text-sm font-semibold text-[#1f1e28] transition hover:bg-white"
             >
               <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-              返回首页
+              Back to home
             </Link>
             <Link
               href="/trending"
               className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-white/10 bg-[#242526] px-5 text-sm font-semibold text-[#f4f4f5] transition hover:border-white/20 hover:bg-[#2c2d2f]"
             >
               <BarChart3 className="h-4 w-4" aria-hidden="true" />
-              查看 Trending
+              View Trending
             </Link>
           </div>
         </div>

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -3,15 +3,15 @@ import { BreadcrumbListJsonLd } from '@/components/json-ld';
 import { ExploreMaintenance } from './maintenance';
 
 export const metadata: Metadata = {
-  title: 'Data Explorer 维护中',
-  description: 'OSSInsight Data Explorer 正在维护中，暂时不可用。',
+  title: 'Data Explorer — Under Maintenance',
+  description: 'OSSInsight Data Explorer is under maintenance and temporarily unavailable.',
   openGraph: {
-    title: 'Data Explorer 维护中 | OSSInsight',
-    description: 'OSSInsight Data Explorer 正在维护中，暂时不可用。',
+    title: 'Data Explorer — Under Maintenance | OSSInsight',
+    description: 'OSSInsight Data Explorer is under maintenance and temporarily unavailable.',
   },
   twitter: {
-    title: 'Data Explorer 维护中 | OSSInsight',
-    description: 'OSSInsight Data Explorer 正在维护中，暂时不可用。',
+    title: 'Data Explorer — Under Maintenance | OSSInsight',
+    description: 'OSSInsight Data Explorer is under maintenance and temporarily unavailable.',
     card: 'summary_large_image',
   },
   alternates: { canonical: '/explore' },


### PR DESCRIPTION
## Summary
The Data Explorer maintenance page shipped in #3089 is written in Chinese, but ossinsight.io is an English-language site. This translates it to English.

Changed:
- `apps/web/app/explore/maintenance.tsx` — visible copy (heading, body, both buttons, the "Under maintenance" eyebrow).
- `apps/web/app/explore/page.tsx` — metadata `title` / `description` / OpenGraph / Twitter. The page `<title>` was `Data Explorer 维护中`, which is what showed up in search results and social cards.
- `apps/web/app/api/explorer/ask/route.ts` — the `message` field of the 503 `EXPLORER_UNDER_MAINTENANCE` response.

Copy-only. Layout, styling, and the maintenance short-circuit itself are unchanged — this does **not** re-enable Data Explorer.

## Test Plan
- `pnpm --filter web build` passes (exit 0); `/explore` still prerenders as static.
- `curl http://127.0.0.1:3011/explore` returns 200, `<title>Data Explorer — Under Maintenance | OSSInsight</title>`, and contains "Data Explorer is under maintenance" / "Back to home" / "View Trending".
- `curl -X POST http://127.0.0.1:3011/api/explorer/ask -d '{"question":"..."}'` returns 503 with `"message":"Data Explorer is under maintenance and temporarily unavailable."`
- Grepped the rendered HTML for CJK codepoints — none remain.
- Rendered screenshot checked at 1440x900; layout identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)