### PR TITLE
web: stop baking empty AI treemap data into the homepage

### DIFF
--- a/apps/web/app/ai-home-content.tsx
+++ b/apps/web/app/ai-home-content.tsx
@@ -365,6 +365,12 @@ export default function AIHomeContent({ categories, trendingRepos }: AIHomeProps
     };
   }, [trendingRepos]);
 
+  // No data (upstream query failed or returned nothing): render nothing rather
+  // than a 500px-tall blank ECharts canvas with a stray Download button.
+  if (trendingRepos.length === 0) {
+    return null;
+  }
+
   return (
     <section className="py-8">
       <div className="relative mx-auto max-w-[1280px] px-6">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,7 +6,10 @@ import ShareButtons from '@/components/ShareButtons';
 import AIHomeContent from './ai-home-content';
 import { getCategoryData, getAITrending, getTrendingForTreemap } from './ai-home-data';
 
-export const revalidate = 3600;
+// Rendered per request: the AI treemap/category data is fetched server-side from
+// TiDB, and prerendering it at build time bakes in whatever the build host could
+// reach. Matches the treatment the analyze routes got in 06e1ff5.
+export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: {


### PR DESCRIPTION
## Problem
The AI ecosystem treemap on the homepage renders as a ~612px blank area with only the "Download 4K" button. Measured on ossinsight.io at 1440x900:

| section | height | content |
|---|---|---|
| Hero | 448px | ok |
| **AI treemap** | **612px** | **only "Download 4K"** |
| Trending Repos | 2821px | ok |
| Hot Collections | 380px | ok |
| FAQ | 567px | ok |

## Cause
`app/page.tsx` sets `export const revalidate = 3600`, so the page is prerendered at build time. `getCategoryData()` and `getTrendingForTreemap()` fetch server-side from TiDB and both swallow failures into empty arrays (`ai-home-data.ts:44`, `:127`). If the build host can't reach the database, that empty result is baked into the prerender.

The currently-served HTML carries the fallback values:
```
"trendingRepos":[]
"categories":[{"id":10098,...,"repos":[],"totalStarsEarned":0,"repoCount":0,"topMover":null}, ...]
```

The same queries are fine at runtime — `/api/q/trending-repos?language=All&period=past_month` returns 100 rows right now. That's why the client-fetched Trending Repos and Hot Collections sections still work while the server-fetched treemap doesn't.

Worth noting the served page is also stuck: `x-nextjs-prerender: 1`, `x-vercel-cache: STALE`, `age: 3036021` (~35 days, ~843x past the 1h revalidate window), so the empty prerender has not been replaced on its own.

## Changes
- **`app/page.tsx`** — `revalidate = 3600` to `dynamic = 'force-dynamic'`, so data is fetched per request with runtime credentials instead of baked at build. Same treatment the analyze routes got in 06e1ff5.
- **`app/ai-home-content.tsx`** — early return when `trendingRepos` is empty, so a data blip degrades to "section absent" instead of a 500px blank canvas. Placed after all hooks, so hook order is unchanged.

## Test Plan
- `pnpm --filter web build` passes (exit 0).
- Route table changes from `○ /` (Static) to `ƒ /` (Dynamic); `.next/server/app/index.html` is no longer emitted, confirming nothing is baked at build.
- Reproduced the bug locally first: a build with no `DATABASE_URL` produced the identical `"trendingRepos":[]` prerender.
- With the fix, `next start` + no `DATABASE_URL` (worst case) renders Hero -> Trending Repos -> Hot Collections -> FAQ with the treemap section absent. No blank region.

## Tradeoff
`force-dynamic` means the homepage is no longer CDN-cached and runs ~10 queries per request (8 category rankings + trending + topics); `collection-stars-last-28-days-rank` measured ~1.2s. That's the straightforward fix and matches what the analyze routes already do, but if homepage load is a concern, a follow-up could wrap the two fetchers in a server-side data cache, or move the treemap to client-side fetching like the neighbouring sections. Happy to redo it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)