### PR TITLE
web: stop publishing star rankings built on degraded event data

### DIFF
--- a/apps/web/app/ai-home-content.tsx
+++ b/apps/web/app/ai-home-content.tsx
@@ -367,6 +367,8 @@ export default function AIHomeContent({ categories, trendingRepos }: AIHomeProps
 
   // No data (upstream query failed or returned nothing): render nothing rather
   // than a 500px-tall blank ECharts canvas with a stray Download button.
+  // Also covers the degraded-data incident, where page.tsx stops fetching:
+  // the Trending Repos section carries the single user-facing notice.
   if (trendingRepos.length === 0) {
     return null;
   }

--- a/apps/web/app/home-content.tsx
+++ b/apps/web/app/home-content.tsx
@@ -23,6 +23,8 @@ import {
   TagIcon,
 } from '@primer/octicons-react';
 import { getCollectionsHotPath } from '@/lib/collections';
+import { isStarRankingDegraded } from '@/lib/data-quality';
+import { DataQualityNotice } from '@/components/DataQualityNotice';
 import { type CollectionQueryResponse, useCollectionApi } from '@/lib/collections-client';
 import { useRemoteData, getRemoteDataQueryKey } from '@/utils/useRemoteData';
 import { queryAPI } from '@/utils/api';
@@ -1001,7 +1003,8 @@ function TrendingReposSection() {
     language: language === 'All' ? 'All' : language,
   }), [period, language]);
 
-  const { data, loading } = useRemoteData<TrendingRepo>('trending-repos', params);
+  const degraded = isStarRankingDegraded();
+  const { data, loading } = useRemoteData<TrendingRepo>('trending-repos', params, !degraded);
   const allRepos = data?.data ?? [];
   const totalCount = allRepos.length;
   const repos = allRepos.slice(page * rowsPerPage, (page + 1) * rowsPerPage);
@@ -1009,6 +1012,16 @@ function TrendingReposSection() {
 
   // Reset page when filters change
   useEffect(() => { setPage(0); }, [period, language]);
+
+  if (degraded) {
+    return (
+      <section className="px-6 pt-16 pb-8 max-w-[1536px] mx-auto">
+        <a id="trending-repos" />
+        <h2 className="text-2xl font-bold mb-4">&#x1F525; Trending Repos</h2>
+        <DataQualityNotice />
+      </section>
+    );
+  }
 
   return (
     <section className="px-6 pt-16 pb-8 max-w-[1536px] mx-auto">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,7 +4,8 @@ import { FAQPageJsonLd, SiteApplicationJsonLd, WebPageJsonLd } from '@/component
 import { FAQ_ITEMS } from './faq-data';
 import ShareButtons from '@/components/ShareButtons';
 import AIHomeContent from './ai-home-content';
-import { getCategoryData, getAITrending, getTrendingForTreemap } from './ai-home-data';
+import { getCategoryData, getTrendingForTreemap } from './ai-home-data';
+import { isStarRankingDegraded } from '@/lib/data-quality';
 
 // Rendered per request: the AI treemap/category data is fetched server-side from
 // TiDB, and prerendering it at build time bakes in whatever the build host could
@@ -36,10 +37,12 @@ export const metadata: Metadata = {
 };
 
 export default async function HomePage() {
-  const [categories, trendingRepos] = await Promise.all([
-    getCategoryData(),
-    getTrendingForTreemap(),
-  ]);
+  // While star data is degraded the treemap is not rendered, so skip the
+  // ~10 WatchEvent-derived queries that would feed it.
+  const degraded = isStarRankingDegraded();
+  const [categories, trendingRepos] = degraded
+    ? [[], []]
+    : await Promise.all([getCategoryData(), getTrendingForTreemap()]);
 
   return (
     <>

--- a/apps/web/app/trending/ai/content.tsx
+++ b/apps/web/app/trending/ai/content.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo } from 'react';
 import Link from 'next/link';
 import { ArrowUp, ArrowDown, Star, TrendingUp, ChevronRight, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { isStarRankingDegraded } from '@/lib/data-quality';
+import { DataQualityNotice } from '@/components/DataQualityNotice';
 import type { TrendingAIResponse, AIRepoItem } from './api/route';
 
 const CATEGORIES = [
@@ -132,6 +134,7 @@ export function TrendingAIContent({
       </section>
 
       <div className="mx-auto max-w-6xl px-4 py-8">
+        {isStarRankingDegraded() && <DataQualityNotice variant="inline" className="mb-6" />}
         {/* Category Filter Tabs */}
         <div className="mb-8 flex flex-wrap gap-2">
           {CATEGORIES.map((cat) => (

--- a/apps/web/app/trending/page.tsx
+++ b/apps/web/app/trending/page.tsx
@@ -7,6 +7,8 @@ import {
   getTrendingRepos,
 } from '@/lib/server/internal-api';
 import { TrendingContent } from './content';
+import { isStarRankingDegraded } from '@/lib/data-quality';
+import { DataQualityNotice } from '@/components/DataQualityNotice';
 
 export const revalidate = 3600;
 
@@ -45,10 +47,14 @@ export default async function TrendingPage({ searchParams }: PageProps) {
     total_score: number;
   }> = [];
 
-  try {
-    repos = await getTrendingRepos(language, period);
-  } catch (err) {
-    // query failed – continue with empty repos
+  const degraded = isStarRankingDegraded();
+
+  if (!degraded) {
+    try {
+      repos = await getTrendingRepos(language, period);
+    } catch (err) {
+      // query failed – continue with empty repos
+    }
   }
 
   const jsonLd = {
@@ -74,7 +80,7 @@ export default async function TrendingPage({ searchParams }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      {repos.length > 0 && (
+      {!degraded && repos.length > 0 && (
         <ItemListJsonLd
           name="Trending GitHub Repositories"
           items={repos.map((r) => ({
@@ -83,13 +89,23 @@ export default async function TrendingPage({ searchParams }: PageProps) {
           }))}
         />
       )}
-      <TrendingContent
-        repos={repos}
-        period={period}
-        language={language}
-        languages={LANGUAGES as unknown as string[]}
-        periods={PERIODS as unknown as Array<{ value: string; label: string }>}
-      />
+      {degraded ? (
+        <main className="mx-auto w-full max-w-[1536px] px-6 py-16">
+          <h1 className="mb-2 text-3xl font-bold">&#x1F525; Trending Repositories</h1>
+          <p className="mb-8 text-sm text-gray-400">
+            Ranked by community activity across GitHub.
+          </p>
+          <DataQualityNotice />
+        </main>
+      ) : (
+        <TrendingContent
+          repos={repos}
+          period={period}
+          language={language}
+          languages={LANGUAGES as unknown as string[]}
+          periods={PERIODS as unknown as Array<{ value: string; label: string }>}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/components/DataQualityNotice.tsx
+++ b/apps/web/components/DataQualityNotice.tsx
@@ -1,0 +1,49 @@
+import { AlertTriangle } from 'lucide-react';
+import { STAR_DATA_INCIDENT } from '@/lib/data-quality';
+
+/**
+ * Shown in place of a ranking we know is wrong (`variant="block"`), or above
+ * a surface where only some columns are affected (`variant="inline"`).
+ */
+export function DataQualityNotice({
+  variant = 'block',
+  className = '',
+}: {
+  variant?: 'block' | 'inline';
+  className?: string;
+}) {
+  if (variant === 'inline') {
+    return (
+      <div
+        role="status"
+        className={`flex items-start gap-2.5 rounded-md border border-[#FFE895]/25 bg-[#FFE895]/[0.06] px-3.5 py-2.5 text-sm text-[#d8d8d8] ${className}`}
+      >
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[#FFE895]" aria-hidden="true" />
+        <p>
+          Growth figures below are derived from GitHub&apos;s public events feed, which has been
+          incomplete since {STAR_DATA_INCIDENT.severelyDegradedSince}. Treat them as lower bounds.
+          Total star counts come directly from GitHub and are accurate.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      className={`rounded-lg border border-dashed border-[#3c3c3c] bg-[#212122] px-6 py-8 ${className}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-white/10 bg-[#2a2a2b] text-[#FFE895]">
+          <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="max-w-2xl">
+          <h3 className="text-base font-semibold text-[#f4f4f5]">
+            {STAR_DATA_INCIDENT.headline}
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-[#b4b4b4]">{STAR_DATA_INCIDENT.body}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/data-quality.ts
+++ b/apps/web/lib/data-quality.ts
@@ -1,0 +1,63 @@
+/**
+ * Star/PR/issue metrics on OSSInsight are derived from GitHub's global public
+ * events firehose (`https://api.github.com/events`), which the ETL ingests in
+ * `etl/config/initializers/fetch_event.rb`.
+ *
+ * GitHub has progressively stopped emitting most non-Push event types through
+ * that firehose. Measured 2026-08-19 against GH Archive hourly dumps (50k
+ * events/month, same hour of day):
+ *
+ *   2025-06  Push 59.1%  Watch 2.96%  PR 7.95%
+ *   2026-04  Push 73.1%  Watch 2.20%  PR 5.74%
+ *   2026-06  Push 87.2%  Watch 0.05%  PR 0.26%
+ *   2026-08  Push 95.4%  Watch 0.22%  PR 0.96%
+ *
+ * A live sample of 500 events from the firehose returned zero WatchEvent and
+ * zero IssuesEvent. GH Archive and its mirrors (BigQuery, ClickHouse,
+ * ecosyste.ms, OpenDigger) are fed by the same firehose, so they are equally
+ * affected. Repo-scoped `/repos/{owner}/{repo}/events` still returns a full
+ * event mix, and GraphQL `stargazerCount` still works.
+ *
+ * Consequence: any ranking derived from WatchEvent rows is meaningless. The
+ * `past_24_hours` trending leaderboard had a top repo with 12 stars and a
+ * median of 1 star.
+ *
+ * This is an explicit incident switch, deliberately not an automatic
+ * threshold: WatchEvent volume is already near zero, so using the degraded
+ * data to decide whether the data is degraded would be circular.
+ *
+ * Flip `active` to false once rankings are driven by `stargazerCount`
+ * snapshot deltas instead of WatchEvent rows.
+ */
+export const STAR_DATA_INCIDENT = {
+  active: true,
+
+  /** First measurable drop in firehose completeness (gharchive.org#310). */
+  suspectSince: '2025-05-23',
+
+  /** Collapse to near-zero non-Push events (gharchive.org#320). */
+  severelyDegradedSince: '2026-05-01',
+
+  headline: 'Star-based rankings are temporarily unavailable',
+
+  body:
+    "GitHub's public events firehose stopped emitting most star, pull request " +
+    'and issue events, so our star-based rankings would be badly misleading. ' +
+    "We've turned them off rather than publish numbers we know are wrong. " +
+    'Repository activity and totals sourced directly from GitHub are unaffected.',
+
+  /** Machine-readable marker for API consumers. */
+  marker: {
+    status: 'degraded' as const,
+    metric: 'watch_event_derived',
+    source: 'github_public_events_firehose',
+    suspect_since: '2025-05-23',
+    severely_degraded_since: '2026-05-01',
+    note: 'Event-derived star/PR/issue counts are lower bounds, not exact values.',
+  },
+} as const;
+
+/** True when a WatchEvent-derived ranking must not be rendered. */
+export function isStarRankingDegraded(): boolean {
+  return STAR_DATA_INCIDENT.active;
+}


### PR DESCRIPTION
## Why

GitHub's global public events firehose (`https://api.github.com/events`, ingested by `etl/config/initializers/fetch_event.rb`) has progressively stopped emitting non-Push event types.

Measured 2026-08-19 against GH Archive hourly dumps, 50k events each, same hour of day:

| month | Push | Watch | Issues | PR |
|---|---|---|---|---|
| 2025-06 | 59.1% | 2.96% | 1.94% | 7.95% |
| 2026-02 | 65.4% | 2.09% | 2.48% | 8.35% |
| 2026-04 | 73.1% | 2.20% | 2.25% | 5.74% |
| **2026-06** | **87.2%** | **0.05%** | **0.08%** | **0.26%** |
| 2026-08 | 95.4% | 0.22% | 0.32% | 0.96% |

A live 500-event sample of the firehose returned **zero** WatchEvent and zero IssuesEvent. Repo-scoped `/repos/{owner}/{repo}/events` still returns a full mix, so this is upstream, not our tokens. GH Archive and its mirrors (BigQuery, ClickHouse, ecosyste.ms, OpenDigger) are fed by the same firehose and are equally affected — switching source does not help.

Corroborated by [gharchive.org#310](https://github.com/igrigorik/gharchive.org/issues/310) and [#320](https://github.com/igrigorik/gharchive.org/issues/320), both open with no maintainer or GitHub response. There is no official GitHub announcement covering the firehose; the [2026-06-30 changelog](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) is a separate change that closed the stargazers/watchers list endpoints.

**Impact:** every WatchEvent-derived ranking is meaningless. `/api/q/trending-repos?period=past_24_hours` currently returns a top repo with **12 stars** and a **median of 1 star**, all obscure brand-new repos — and we were publishing that as `ItemList` structured data to search engines. Star totals are undercounted by ~20% overall (langchain -19.2%, crewAI -34.2%, openai-agents-python -48.2%).

## What this does

One explicit incident switch in `lib/data-quality.ts`. Deliberately **not** an automatic threshold: WatchEvent volume is already near zero, so using the degraded data to decide whether the data is degraded would be circular.

| surface | treatment |
|---|---|
| `/trending` | Ranking replaced with a notice. Repo `ItemList` JSON-LD no longer emitted. |
| homepage Trending Repos | Ranking replaced with the notice; query skipped via `useRemoteData(..., shouldLoad)`. |
| homepage AI treemap | Not rendered; `page.tsx` skips the ~10 WatchEvent-derived queries feeding it. |
| `/trending/ai` | **Kept**, with an inline caveat — it ranks on total stars (synced from GitHub, accurate) but displays 28-day growth (degraded). |

Unaffected: the other 76 of 89 queries, repo activity, and totals sourced directly from GitHub.

Reverting is one boolean: `STAR_DATA_INCIDENT.active = false`.

## Test Plan
- `pnpm --filter web build` — exit 0, zero errors.
- `next start`, verified rendered HTML: `/trending` and `/` each show the notice exactly once; homepage no longer renders the treemap (`Download 4K` count 0); `/trending/ai` shows the inline caveat.
- Confirmed the only remaining `ItemList` on `/trending` is the unrelated Site Navigation JSON-LD, not the repo ranking.
- Screenshot checked at 1440x900.

## Follow-up (not in this PR)
Replace WatchEvent-derived rankings with GraphQL `stargazerCount` snapshot deltas. `packages/sync-github-data` already queries `stargazerCount` and would need an append-only snapshot table plus poll-run metadata. Deltas must be labelled net change, not "stars gained" — unstars are real and must not be clamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)