### PR TITLE
web: surface the degraded-data caveat on affected analyze charts

### DIFF
--- a/apps/web/components/Analyze/Section/Chart.tsx
+++ b/apps/web/components/Analyze/Section/Chart.tsx
@@ -11,6 +11,8 @@ import * as React from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { AnalyzeOwnerContext } from '@/components/Context/Analyze/AnalyzeOwner';
+import { DataQualityNotice } from '@/components/DataQualityNotice';
+import { getWidgetDataQuality } from '@/lib/widget-data-quality';
 import { ShowSQLInline } from '@/components/Analyze/ShowSQL';
 
 export interface ChartTemplateProps {
@@ -94,6 +96,9 @@ export default function ChartTemplate (props: ChartTemplateProps) {
           {React.createElement(titleLevel, { className: TITLE_STYLES[titleLevel] }, title)}
           {sql && <ShowSQLInline sql={sql} queryName={queryName} queryParams={queryParams} />}
         </div>
+      )}
+      {getWidgetDataQuality(name) === 'tainted' && (
+        <DataQualityNotice variant="inline" className="mb-3" />
       )}
       <div
         className={twMerge('relative w-full h-full overflow-hidden', className)}

--- a/apps/web/components/Analyze/Section/OrgChart/endpoints.ts
+++ b/apps/web/components/Analyze/Section/OrgChart/endpoints.ts
@@ -160,3 +160,8 @@ export async function fetchChartData(
 
   return { data, sql, queryName };
 }
+
+/** Preset query names a widget reads, for data-quality classification. */
+export function getOrgEndpointNames(widgetName: string): string[] {
+  return ENDPOINTS[widgetName]?.endpoints ?? [];
+}

--- a/apps/web/components/Analyze/Section/RepoChart/endpoints.ts
+++ b/apps/web/components/Analyze/Section/RepoChart/endpoints.ts
@@ -170,3 +170,8 @@ export async function fetchRepoChartData(
 export function getEndpointConfig(name: string) {
   return ENDPOINTS[name];
 }
+
+/** Preset query names a widget reads, for data-quality classification. */
+export function getRepoEndpointNames(widgetName: string): string[] {
+  return ENDPOINTS[widgetName]?.endpoints ?? [];
+}

--- a/apps/web/components/Analyze/Section/RepoChart/index.tsx
+++ b/apps/web/components/Analyze/Section/RepoChart/index.tsx
@@ -5,6 +5,8 @@ import { createVisualizationContext, createWidgetContext } from '@/lib/charts-co
 import dynamic from 'next/dynamic';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { fetchRepoChartData, type FetchResult } from './endpoints';
+import { DataQualityNotice } from '@/components/DataQualityNotice';
+import { getWidgetDataQuality } from '@/lib/widget-data-quality';
 import { ShowSQLInline } from '@/components/Analyze/ShowSQL';
 import { ChartSkeleton } from '@/components/ui/skeletons';
 import { useChartContainer } from '@/components/Analyze/hooks/useChartContainer';
@@ -139,6 +141,9 @@ export default function RepoChart({
       ) : showSQL ? (
         <div className="flex justify-end mb-1">{sqlButton}</div>
       ) : null}
+      {getWidgetDataQuality(name) === 'tainted' && (
+        <DataQualityNotice variant="inline" className="mb-3" />
+      )}
       <div ref={containerRef} className={`relative w-full overflow-hidden ${className ?? ''}`} style={containerStyle}>
         {ready ? (
           <RepoChartContent vizModule={vizModule} data={fetchResult} ctx={ctx} />

--- a/apps/web/lib/widget-data-quality.ts
+++ b/apps/web/lib/widget-data-quality.ts
@@ -1,0 +1,67 @@
+import { getQueryDataQuality, type QueryDataQuality } from '@/lib/data-quality';
+import { getRepoEndpointNames } from '@/components/Analyze/Section/RepoChart/endpoints';
+import { getOrgEndpointNames } from '@/components/Analyze/Section/OrgChart/endpoints';
+
+/**
+ * Resolve the data-quality tier of a chart widget from the preset queries it
+ * reads.
+ *
+ * The classification is static (configs/data-quality/star-incident-queries.json)
+ * and each widget already declares its endpoints, so this is derived from the
+ * widget name rather than threaded through the runtime datasource: the two
+ * parsers in lib/charts-core/datasource return only the rows, and reshaping
+ * their contract to carry the marker would touch every chart widget for what is
+ * a presentational concern.
+ *
+ * Org endpoint names may contain `{activity}`-style placeholders; those are
+ * expanded against the classification list by prefix so that e.g.
+ * `orgs/{activity}/trends` still matches `orgs/commits/trends`.
+ *
+ * A widget is as degraded as its worst endpoint.
+ */
+export function getWidgetDataQuality(widgetName: string): QueryDataQuality {
+  const names = [...getRepoEndpointNames(widgetName), ...getOrgEndpointNames(widgetName)];
+  if (names.length === 0) {
+    return 'ok';
+  }
+
+  let worst: QueryDataQuality = 'ok';
+  for (const name of names) {
+    const quality = name.includes('{')
+      ? getTemplateQuality(name)
+      : getQueryDataQuality(name);
+    if (quality === 'blocked') {
+      return 'blocked';
+    }
+    if (quality === 'tainted') {
+      worst = 'tainted';
+    }
+  }
+  return worst;
+}
+
+/**
+ * Worst tier across every classified query matching a templated endpoint, so a
+ * widget that can render a degraded activity is treated as degraded.
+ */
+function getTemplateQuality(template: string): QueryDataQuality {
+  const pattern = new RegExp(`^${template.replace(/\{[^}]+\}/g, '[^/]+')}$`);
+  let worst: QueryDataQuality = 'ok';
+  for (const name of listClassifiedQueries()) {
+    if (!pattern.test(name)) continue;
+    const quality = getQueryDataQuality(name);
+    if (quality === 'blocked') return 'blocked';
+    if (quality === 'tainted') worst = 'tainted';
+  }
+  return worst;
+}
+
+let cachedNames: string[] | undefined;
+function listClassifiedQueries(): string[] {
+  if (!cachedNames) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const lists = require('../../../configs/data-quality/star-incident-queries.json');
+    cachedNames = [...(lists.blocked ?? []), ...(lists.tainted ?? [])];
+  }
+  return cachedNames;
+}


### PR DESCRIPTION
Follow-up to #3111, which left one gap: the `tainted` tier was enforced in the API but invisible in the UI.

## Problem

#3111 classified 119 queries as `tainted` — event-derived series that are lower bounds after GitHub's feed changes — and attached a `data_quality` marker to their responses. Nothing rendered it. Both parsers in `lib/charts-core/datasource` return only the rows (`const { data } = await response.json()`), so a visitor to `/analyze/{owner}/{repo}` saw a normal-looking star history chart with a flatlined tail and no explanation for it.

## Approach

Derive the tier from the widget name rather than threading the marker through the runtime datasource. Each widget already declares the preset queries it reads (`RepoChart/endpoints.ts`, `OrgChart/endpoints.ts`) and the classification is static, so `getWidgetDataQuality()` resolves one from the other. Reshaping the datasource contract to carry the marker would have touched every chart widget for what is a presentational concern.

`DataQualityNotice` already had an `inline` variant written for exactly this; it just had no caller.

## One thing worth flagging

Org endpoints use templated names like `analyze-{activity}-map`. A naive lookup misses them, which would have let the stars map and company charts pass as healthy — they read `analyze-stars-map` / `analyze-stars-company`, both tainted. Templates are expanded against the classification list before lookup, and a widget is graded as its worst endpoint.

## Coverage

Of the 17 repo-analyze widgets: **14 tainted** (now carry the notice), **1 blocked**, **2 unaffected** — `commits-time-distribution` and `activity-trends`, verified to have no degraded dependency.

## Test plan

- `pnpm --filter web build` passes (exit 0).
- Classification verified against the shared JSON with template expansion; the two widgets graded healthy were checked individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)