### PR TITLE
etl: read the full event window and make the poller rate-aware

### DIFF
--- a/etl/config/initializers/fetch_event.rb
+++ b/etl/config/initializers/fetch_event.rb
@@ -13,10 +13,23 @@ class FetchEvent
   #     Push-only offset 1-100 partition.
   # Both query params MUST therefore be explicit: per_page=100 and page=1..3.
   # Anything else either misses the healthy mix or fetches nothing extra.
+  #
+  # Measured 2026-09-01: the feed is NOT a stable "latest 300 events" window.
+  # Two requests issued in the same instant return identical bodies, but
+  # requests even one second apart share ZERO event ids, and a single page can
+  # span more than a week of created_at values. Consequently there is no poll
+  # cadence that achieves complete capture, and no diminishing return from
+  # polling faster: distinct events recovered scale with the request budget.
+  # That makes the rate limit the binding constraint, so the poller tracks it
+  # explicitly (see rate_limit_remaining) instead of spinning into 403s.
   PER_PAGE = 100
   MAX_PAGES = 3
 
-  attr_reader :per_page, :token
+  # Stop fetching for this iteration when the token's hourly budget is nearly
+  # gone, leaving room for the other pages and for Realtime to rotate tokens.
+  RATE_LIMIT_FLOOR = 50
+
+  attr_reader :per_page, :token, :rate_limit_remaining, :rate_limit_reset_at
 
   # The per_page argument is kept for call-site compatibility (Realtime passes
   # start.sh's value through) but is pinned to PER_PAGE regardless — see the
@@ -24,6 +37,20 @@ class FetchEvent
   def initialize(per_page, token)
     @per_page = PER_PAGE
     @token = token
+    @rate_limit_remaining = nil
+    @rate_limit_reset_at = nil
+  end
+
+  # True when this token has (almost) no hourly budget left. Realtime uses it
+  # to back off rather than burn the loop on 403s.
+  def rate_limited?
+    !rate_limit_remaining.nil? && rate_limit_remaining <= RATE_LIMIT_FLOOR
+  end
+
+  # Seconds until this token's window resets, or nil when unknown.
+  def seconds_until_reset
+    return nil unless rate_limit_reset_at
+    [(rate_limit_reset_at - Time.now.to_i), 0].max
   end
 
   def url_for(page)
@@ -54,14 +81,32 @@ class FetchEvent
       puts "#{e.class} after retries fetching #{url}"
       nil
     else
+      record_rate_limit(resp)
       resp&.read
     end
+  end
+
+  # GitHub returns the budget on every response; without reading it the poller
+  # cannot tell "no new events" from "we are being throttled".
+  def record_rate_limit(resp)
+    meta = resp&.meta
+    return unless meta
+
+    remaining = meta['x-ratelimit-remaining']
+    reset = meta['x-ratelimit-reset']
+    @rate_limit_remaining = remaining.to_i if remaining
+    @rate_limit_reset_at = reset.to_i if reset
   end
 
   def run
     new_events = []
     fetched_pages = []
     (1..MAX_PAGES).each do |page|
+      if rate_limited?
+        puts "rate limit nearly exhausted (#{rate_limit_remaining} left, resets in #{seconds_until_reset}s); skipping pages #{page}-#{MAX_PAGES} this iteration"
+        break
+      end
+
       json = get_response(page)
       next unless json
 

--- a/etl/config/initializers/fetch_event.rb
+++ b/etl/config/initializers/fetch_event.rb
@@ -3,51 +3,94 @@ require 'open-uri'
 require 'yajl'
 
 class FetchEvent
-  attr_reader :per_page, :url, :token
+  # Since ~2025-05-23 GitHub partitions the /events firehose BY POSITION
+  # (https://github.com/igrigorik/gharchive.org/issues/310):
+  #   - offsets 1-100 (page 1 at per_page=100) are a ~97% PushEvent block;
+  #   - the healthy event mix lives ONLY at offsets 101-300 (pages 2-3);
+  #   - the window is hard-capped at 300 items (page 4 errors out);
+  #   - per_page values over 100 are silently clamped to 100;
+  #   - the DEFAULT per_page=30 would put pages 1-3 entirely inside the
+  #     Push-only offset 1-100 partition.
+  # Both query params MUST therefore be explicit: per_page=100 and page=1..3.
+  # Anything else either misses the healthy mix or fetches nothing extra.
+  PER_PAGE = 100
+  MAX_PAGES = 3
 
+  attr_reader :per_page, :token
+
+  # The per_page argument is kept for call-site compatibility (Realtime passes
+  # start.sh's value through) but is pinned to PER_PAGE regardless — see the
+  # partition note above: any other value silently loses the healthy event mix.
   def initialize(per_page, token)
-    @per_page = per_page
+    @per_page = PER_PAGE
     @token = token
-    @base_url = 'https://api.github.com/events?per_page='
-    @url = @base_url + per_page.to_s
   end
 
-  def get_response
+  def url_for(page)
+    "https://api.github.com/events?per_page=#{per_page}&page=#{page}"
+  end
+
+  def get_response(page)
+    url = url_for(page)
     resp = nil
     begin
       Retryable.retryable(tries: 5, on: [Timeout::Error, Net::OpenTimeout, OpenURI::HTTPError]) do
-        resp = URI.open(url, 
-          open_timeout: 600, 
+        resp = URI.open(url,
+          open_timeout: 600,
           read_timeout: 600,
           'user-agent' => 'ossinsight.io',
           'Authorization' => 'token ' + token
         )
       end
-    rescue OpenURI::HTTPError
-      puts "skip 404 file: #{url}"
+    rescue OpenURI::HTTPError => e
+      # e.message is the real status line (e.g. "403 Forbidden"). This used to
+      # print "skip 404 file" for ANY HTTP error, which hid rate limits and
+      # banned credentials behind a fake 404 for months.
+      puts "HTTP error (#{e.message.strip}) fetching #{url}"
+      nil
+    rescue Timeout::Error, Net::OpenTimeout => e
+      # Contain post-retry timeouts per page so one bad page does not discard
+      # the events already fetched from the other pages this iteration.
+      puts "#{e.class} after retries fetching #{url}"
+      nil
     else
       resp&.read
     end
   end
 
   def run
-    json = get_response
-    if json
-      json = Yajl::Parser.parse(json)
-      new_events = json.map do |event|
-        parse_event(event)
-      end
+    new_events = []
+    fetched_pages = []
+    (1..MAX_PAGES).each do |page|
+      json = get_response(page)
+      next unless json
 
-      new_event_ids = new_events.map { |e| e['id'].to_i }
-      exist_event_ids = EventLog.where(id: new_event_ids).pluck(:id)
-      real_events = new_events.reject{ |e| exist_event_ids.include?(e['id'].to_i) }
-      
-      real_events.each_slice(33) do |es|
-        EventLog.insert_all(es.map{|e| {id: e['id'], created_at: Time.now}})
-        GithubEvent.insert_all(es)
-      end
-    else
-      puts "No response"
+      new_events.concat(Yajl::Parser.parse(json).map { |event| parse_event(event) })
+      fetched_pages << page
+    end
+
+    if fetched_pages.empty?
+      puts "No response (all #{MAX_PAGES} pages failed)"
+      return
+    end
+    if fetched_pages.size < MAX_PAGES
+      puts "degraded fetch: only page(s) #{fetched_pages.join(',')} of #{MAX_PAGES} succeeded"
+    end
+
+    # Intra-batch dedup is REQUIRED before the EventLog check: the firehose
+    # shifts between the three page requests, so the same event id can appear
+    # on two pages, and github_events has NO primary/unique key — a duplicate
+    # that survives to insert_all is inserted twice. EventLog's PK only guards
+    # against ids seen in PREVIOUS runs, not within this merged batch.
+    new_events = new_events.uniq { |e| e['id'].to_i }
+
+    new_event_ids = new_events.map { |e| e['id'].to_i }
+    exist_event_ids = EventLog.where(id: new_event_ids).pluck(:id)
+    real_events = new_events.reject{ |e| exist_event_ids.include?(e['id'].to_i) }
+
+    real_events.each_slice(33) do |es|
+      EventLog.insert_all(es.map{|e| {id: e['id'], created_at: Time.now}})
+      GithubEvent.insert_all(es)
     end
   end
 

--- a/etl/config/initializers/realtime.rb
+++ b/etl/config/initializers/realtime.rb
@@ -3,18 +3,44 @@ require_relative './fetch_event'
 class Realtime
   attr_reader :tokens, :per_page, :tokens_count
 
+  # The /events feed shares no event ids between polls even one second apart
+  # (measured 2026-09-01), so distinct events captured scale with the request
+  # budget and the hourly rate limit is the binding constraint. Each iteration
+  # now costs 3 requests instead of 1 (offsets 1-300 rather than the Push-only
+  # first page), so the loop must notice throttling instead of spinning on it.
+  #
+  # When every token is exhausted, sleep until the earliest reset rather than
+  # hammering GitHub with 403s, which risks secondary rate limiting on top of
+  # the primary one.
+  MAX_BACKOFF_SECONDS = 60
+
   def initialize(tokens, per_page)
     raise "You need to create github token here: https://github.com/settings/tokens, and set GITHUB_TOKEN env." if tokens.blank?
     @tokens = tokens
     @per_page = per_page
     @tokens_count = @tokens.size
+    # token => Time at which its hourly window resets, for tokens known to be spent.
+    @exhausted_until = {}
   end
 
   def run
-    loop do 
-      token = tokens[rand(tokens_count)]
+    loop do
+      token = next_available_token
+      if token.nil?
+        wait = backoff_seconds
+        puts "all #{tokens_count} token(s) rate limited; sleeping #{wait}s"
+        sleep wait
+        next
+      end
+
       begin
-        FetchEvent.new(per_page, token).run
+        fetcher = FetchEvent.new(per_page, token)
+        fetcher.run
+        if fetcher.rate_limited?
+          @exhausted_until[token] = Time.now.to_i + (fetcher.seconds_until_reset || MAX_BACKOFF_SECONDS)
+        else
+          @exhausted_until.delete(token)
+        end
       rescue
         ActiveRecord::Base.connection.reconnect!
         puts $!
@@ -24,5 +50,26 @@ class Realtime
 
   def self.clean!
     EventLog.where("created_at <= ?", 5.minutes.ago).limit(100000).delete_all
+  end
+
+  private
+
+  # A token whose window is known to have reset, preferring an unseen one.
+  def next_available_token
+    now = Time.now.to_i
+    available = tokens.reject { |t| (@exhausted_until[t] || 0) > now }
+    return nil if available.empty?
+
+    available[rand(available.size)]
+  end
+
+  # Time until the earliest token resets, clamped so a bad reset header cannot
+  # stall ingestion for an hour.
+  def backoff_seconds
+    now = Time.now.to_i
+    soonest = @exhausted_until.values.min
+    return MAX_BACKOFF_SECONDS if soonest.nil?
+
+    [[soonest - now, 1].max, MAX_BACKOFF_SECONDS].min
   end
 end


### PR DESCRIPTION
Stops the ongoing star/PR/issue data loss at the source. This is the fix that determines what data we have *going forward* — every day it is not deployed is a day permanently missing from the record.

## Root cause

GitHub partitions `/events` **by position**, and our poller only ever read the first slice:

```ruby
# before
@url = 'https://api.github.com/events?per_page=' + per_page.to_s   # no page param
```

Measured live:

| | PushEvent | the rest |
|---|---|---|
| page 1 (offsets 1-100) | 95/100 | CreateEvent 3, DeleteEvent 2 |
| page 2 (101-200) | **0** | PullRequestEvent 46, IssueComment 17, ... |
| page 3 (201-300) | **0** | PullRequestEvent 34, IssueComment 15, ... |

`per_page` is silently clamped to 100 and the window caps at 300 items, so both params have to be explicit — the API default of `per_page=30` would put pages 1-3 *entirely inside* the Push-only partition. That detail is why this is a two-line change that is easy to get subtly wrong.

## What this measured that changes the design

The feed is **not** a stable "latest 300 events" window:

- two requests in the same instant return byte-identical bodies;
- requests **one second apart share zero event ids**;
- a single page spans **more than a week** of `created_at` values.

So there is no poll cadence that achieves complete capture, and no diminishing return from polling faster — distinct events recovered scale with the request budget. **The hourly rate limit is the binding constraint**, which matters because this change triples the per-iteration request cost while `realtime.rb` polls in a tight loop with no sleep, no rate-limit check, and a bare `rescue`. Without rate awareness the fix would spend its new budget on 403s and risk secondary rate limiting.

## Changes

**`fetch_event.rb`** — fetch pages 1..3 with explicit `per_page=100&page=N`; dedup the merged batch by event id *before* the `EventLog` check; contain per-page failures so one bad page no longer discards the others; record `x-ratelimit-remaining`/`reset` and stop mid-iteration when the token is nearly spent. Also log the real HTTP status line instead of printing `skip 404 file` for every error, which hid rate limits and bad credentials behind a fake 404.

**`realtime.rb`** — track which tokens are spent, rotate to one whose window has reset, and sleep until the earliest reset (clamped to 60s) when all are exhausted.

## The dedup is not theoretical

In the end-to-end run below, **296 fetched rows merged to 235 — 61 real cross-page duplicates**. `github_events` has no primary key and no unique index, and `EventLog` only guards against ids seen in *previous* runs, so without the intra-batch `uniq` those 61 would each be inserted twice.

## Test plan

- `ruby -c` passes on both files.
- End-to-end against the live API with a real token: page composition as tabulated above; 296 → 235 after dedup; **WatchEvent 2.98%**, against the 3.02% pre-incident baseline; rate-limit headers read correctly (`remaining: 4964`).
- `EventLog` cross-run dedup, `insert_all` slicing and token rotation are unchanged; `Realtime`'s `FetchEvent.new(per_page, token)` call site still works (the value is pinned to 100 internally).

## Deploy note

The ETL runs outside this repo (`start.sh` in a container, host unknown), so merging does not deploy it — someone with access to that host needs to restart the container. Until then the loss continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)