### PR TITLE
api-server: stop the response schema from stripping data_quality

### DIFF
--- a/packages/api-server/src/utils/endpoint.ts
+++ b/packages/api-server/src/utils/endpoint.ts
@@ -68,10 +68,16 @@ export function proxyGet(
         // break those integrations and fire their alerting for a known data
         // condition. The empty `rows` must not be read as "no results" - that is
         // what `status: "unavailable"` is for.
+        // .serializer() bypasses the route's response schema, which otherwise
+        // strips data_quality: the schema describes the upstream Data Service
+        // shape and has no property for it, so Fastify would silently drop the
+        // one field that explains why rows is empty.
         reply
           .code(200)
           .header('Cache-Control', 'no-store')
           .header('Warning', '199 - "degraded data: star-event derived ranking unavailable"')
+          .type('application/json; charset=utf-8')
+          .serializer((payload: unknown) => JSON.stringify(payload))
           .send({
             type: 'sql_endpoint',
             data: { columns: [], rows: [], result: { row_count: 0 } },
@@ -94,6 +100,7 @@ export function proxyGet(
           .code(res.status)
           .headers(res.headers)
           .header('Warning', '199 - "degraded data: event-derived counts are lower bounds"')
+          .serializer((payload: unknown) => JSON.stringify(payload))
           .send(body);
         return;
       }


### PR DESCRIPTION
Found while deploying #3111's `/v1` gate to api1 and api2.

The block worked — empty rows, `Warning` header, no more 31-star "trending" leaderboard — but the body was missing the one field that explains the emptiness:

```json
{"type":"sql_endpoint","data":{"columns":[],"rows":[],"result":{"row_count":0}}}
```

`proxyGet` passes a response schema describing the upstream Data Service shape. It has no property for `data_quality`, so Fastify's schema serializer silently dropped it — turning an explicit "unavailable" envelope back into a bare empty result, which is precisely the ambiguity the envelope exists to remove. A consumer would read it as "no trending repos today".

Overriding the serializer on both degraded paths fixes it.

## Verified through the public nginx (load-balances both api hosts)

| endpoint | result |
|---|---|
| `/v1/trends/repos` ×6 | `rows=0`, `status=unavailable` on all six |
| `/v1/collections/hot` | `rows=0`, `status=unavailable` |
| `/v1/collections/{id}/ranking_by_stars` | `rows=0`, `status=unavailable` |
| `/v1/repos/{o}/{r}/stargazers/history` | **132 real rows**, `status=degraded` |
| `/v1/collections` (untouched) | 138 rows, no marker |

Pre-existing and unrelated: several `/v1` endpoints return HTTP 500 `"Request failed with status code 404"` from the upstream Data Service (`repos/{o}/{r}/overview`, `issues/monthly`, `pull_requests/monthly`, `orgs/{org}/repos`, `committers`). Endpoints outside both gate lists fail identically, so this is not caused by the gate — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)