### PR TITLE
sync-github-data: snapshot daily stargazer counts for collection repos

### DIFF
--- a/.github/workflows/daily-star-snapshots.yml
+++ b/.github/workflows/daily-star-snapshots.yml
@@ -1,0 +1,64 @@
+# Daily stargazer count snapshots for all collection repos.
+#
+# Since ~2025-05 the GitHub /events firehose no longer delivers a usable star-event
+# stream, so star rankings are moving from WatchEvent flow to snapshot deltas. This
+# job records the authoritative running total (GraphQL `stargazerCount`) once per
+# day into the `sys_repo_star_snapshots` table. Every day this job does not run is
+# a data point that can never be recovered, which is why it is scheduled daily and
+# why the command is idempotent (safe to re-run / re-dispatch on the same day).
+#
+# Required repository secrets:
+# - DATABASE_URL: TiDB connection string in Prisma mysql format, e.g.
+#   mysql://user:password@host:4000/gharchive_dev?sslaccept=strict
+#   (same cluster/database as the existing "Sync Collection Configs" workflow;
+#   note that Prisma needs the `sslaccept=strict` query parameter for TiDB
+#   Serverless, unlike the @tidbcloud/serverless driver).
+# - GH_ACCESS_TOKENS (optional): comma-separated GitHub personal access tokens
+#   (public repo read access is enough). When absent, the workflow falls back to
+#   the built-in GITHUB_TOKEN, whose 1,000 GraphQL points/hour are still ample:
+#   the whole run costs ~250 points (~2.5k repos at ~10 repos per point).
+name: Daily Star Snapshots
+
+on:
+  schedule:
+    # Daily at 00:23 UTC, right after the UTC day rollover, so the snapshot day
+    # matches the day the counts are observed as closely as possible.
+    - cron: '23 0 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Fetch stargazer counts but skip all database writes'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    # Do not run the cron on forks; manual dispatch works anywhere.
+    if: github.repository == 'pingcap/ossinsight' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        # The pnpm version is taken from the "packageManager" field in package.json.
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --filter @ossinsight/sync-github-data
+
+      - name: Build CLI
+        run: pnpm --filter @ossinsight/sync-github-data build
+
+      - name: Snapshot stargazer counts
+        run: pnpm --filter @ossinsight/sync-github-data start repos snapshot-stars ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          GITHUB_ACCESS_TOKENS: ${{ secrets.GH_ACCESS_TOKENS || secrets.GITHUB_TOKEN }}

--- a/configs/materialized_views/sys_repo_star_snapshots/ddl.sql
+++ b/configs/materialized_views/sys_repo_star_snapshots/ddl.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `sys_repo_star_snapshots`
+(
+    `repo_id` BIGINT NOT NULL COMMENT 'The repository ID (github_repos.repo_id / GraphQL databaseId).',
+    `snapshot_day` DATE NOT NULL COMMENT 'The UTC day this snapshot belongs to.',
+    `stargazer_count` INT NOT NULL COMMENT 'Total stargazers reported by the GitHub GraphQL API (stargazerCount) at retrieval time.',
+    `forks_count` INT NULL COMMENT 'Total forks reported by the GitHub GraphQL API (forkCount) at retrieval time.',
+    `retrieved_at` DATETIME NOT NULL COMMENT 'When the value was actually fetched from the API (UTC).',
+    `source` VARCHAR(32) NOT NULL DEFAULT 'github_graphql' COMMENT 'Provenance of the snapshot, for example: github_graphql.',
+    PRIMARY KEY (`repo_id`, `snapshot_day`)
+);

--- a/packages/sync-github-data/README.md
+++ b/packages/sync-github-data/README.md
@@ -30,3 +30,59 @@ pnpm run dev:start users sync-in-batch
 ```shell
 pnpm run dev:start repos sync-in-batch
 ```
+
+#### Snapshot daily stargazer counts for collection repos
+
+```shell
+pnpm run build
+pnpm run start repos snapshot-stars
+```
+
+Records today's total stargazer count (GitHub GraphQL `stargazerCount`) and fork count for
+every repo that belongs to an active collection into the `sys_repo_star_snapshots` table
+(DDL: `configs/materialized_views/sys_repo_star_snapshots/ddl.sql`, applied automatically
+via `CREATE TABLE IF NOT EXISTS` on the first write).
+
+**Why this table exists.** Since ~2025-05 the GitHub `/events` firehose no longer delivers a
+usable star-event stream, so star rankings can no longer be derived from `WatchEvent` flow in
+`github_events`. The plan is to move rankings to **snapshot deltas**: today's `stargazer_count`
+minus an earlier day's is a trustworthy "stars gained" signal that does not depend on the
+event stream at all (it even accounts for un-stars, which the event stream never did).
+
+**Why it must run daily.** `stargazerCount` is a running total — GitHub exposes no per-day
+history. A day without a snapshot is a data point that can never be recovered, and every
+missed day widens the window a delta has to span. The job is idempotent: the table's primary
+key is `(repo_id, snapshot_day)` and writes use `ON DUPLICATE KEY UPDATE`, so re-running it
+on the same day is always safe.
+
+The scheduled entry point is the `.github/workflows/daily-star-snapshots.yml` workflow
+(daily cron + manual dispatch). To run it anywhere else, schedule the equivalent of:
+
+```shell
+# Required: GITHUB_ACCESS_TOKENS, DATABASE_URL
+pnpm run build
+pnpm run start repos snapshot-stars
+```
+
+Useful flags:
+
+```shell
+# Verify without writing to the database (still requires DATABASE_URL to load the repo list).
+pnpm run start repos snapshot-stars --dry-run
+
+# Verify without any database credentials at all (repo list given explicitly,
+# GITHUB_ACCESS_TOKENS is still required for the GraphQL lookups).
+pnpm run start repos snapshot-stars --dry-run --repos=41986369:pingcap/tidb,vuejs/core
+
+# Tune how many repos are looked up per GraphQL request (default: 10, ~1 rate-limit
+# point per request), and pin the UTC day the snapshots are recorded under.
+pnpm run start repos snapshot-stars --batch-size=10 --snapshot-day=2026-08-27
+```
+
+Unresolvable repos (deleted, made private, or renamed without a redirect) are logged,
+skipped and counted — a dead repo never fails the run. A summary line
+(`repos_processed / snapshots_written / failures`) is printed at the end.
+
+Note: `DATABASE_URL` is validated per command instead of at CLI start-up, so the
+credential-free dry-run above works; commands that do touch the database fail with a clear
+error when it is missing. `GITHUB_ACCESS_TOKENS` is always required.

--- a/packages/sync-github-data/package.json
+++ b/packages/sync-github-data/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist && prisma generate && pnpm run build:ts",
     "build:ts": "tsc",
     "watch:ts": "tsc -w",
-    "start": "node dist/index.js",
+    "start": "TS_NODE_BASEURL=./dist node -r tsconfig-paths/register dist/index.js",
     "dev:start": "ts-node -r tsconfig-paths/register src/index.ts"
   },
   "keywords": [],

--- a/packages/sync-github-data/prisma/schema.prisma
+++ b/packages/sync-github-data/prisma/schema.prisma
@@ -121,6 +121,21 @@ model GitHubEvent {
   @@map("github_events")
 }
 
+// Daily total-star snapshots for collection repos, written by the
+// `repos snapshot-stars` command through raw SQL. The table DDL lives in
+// `configs/materialized_views/sys_repo_star_snapshots/ddl.sql`.
+model SysRepoStarSnapshot {
+  repoId         BigInt   @map("repo_id")
+  snapshotDay    DateTime @db.Date @map("snapshot_day")
+  stargazerCount Int      @map("stargazer_count")
+  forksCount     Int?     @map("forks_count")
+  retrievedAt    DateTime @db.DateTime(0) @map("retrieved_at")
+  source         String   @default("github_graphql") @db.VarChar(32)
+
+  @@id([repoId, snapshotDay])
+  @@map("sys_repo_star_snapshots")
+}
+
 model LocationCacheItem {
   address          String   @id
   valid            Boolean

--- a/packages/sync-github-data/src/commands/repos/snapshot-stars.ts
+++ b/packages/sync-github-data/src/commands/repos/snapshot-stars.ts
@@ -1,0 +1,236 @@
+import {RepoStarSnapshot, RepoStarSnapshotDao} from "@dao/repo-star-snapshot-dao";
+import {AppConfig} from "@env";
+import {processInBatch} from "@libs/concurrent";
+import {GitHubHelper} from "@libs/github/helper";
+import {createOctokitPool} from "@libs/github/octokit";
+import {PrismaClient} from "@prisma/client";
+import {Command, InvalidArgumentError} from "commander";
+import {DateTime} from "luxon";
+import {Logger} from "pino";
+
+export const SNAPSHOT_SOURCE_GITHUB_GRAPHQL = 'github_graphql';
+
+// ~10 aliased repository lookups per GraphQL request costs about 1 rate-limit
+// point, so the whole collection repo universe (~2.5k repos) fits into a few
+// hundred points out of 5,000/hour/token.
+export const DEFAULT_SNAPSHOT_BATCH_SIZE = 10;
+export const MAX_SNAPSHOT_BATCH_SIZE = 100;
+
+// The full set of repos that appear in any active (non-deleted) collection.
+// Prefer github_repos.repo_name (kept fresh by the other sync commands) over
+// the collection_items copy, which can go stale after a repo rename.
+const COLLECTION_REPOS_SQL = `
+    SELECT DISTINCT ci.repo_id                           AS repoId,
+                    COALESCE(gr.repo_name, ci.repo_name) AS repoName
+    FROM collection_items ci
+             JOIN collections c ON c.id = ci.collection_id AND c.deleted_at IS NULL
+             LEFT JOIN github_repos gr ON gr.repo_id = ci.repo_id AND gr.is_deleted = 0
+    WHERE ci.deleted_at IS NULL
+`;
+
+export interface Options {
+  dryRun: boolean;
+  batchSize: number;
+  repos?: string;
+  snapshotDay?: string;
+}
+
+export interface TargetRepo {
+  repoId: number | null;
+  repoName: string;
+}
+
+/**
+ * @sub-command sync-github repos snapshot-stars
+ * @description Record a daily stargazer count snapshot for every collection repo.
+ */
+export function initSnapshotStarsCommand(pCommand: Command, config: AppConfig, logger: Logger) {
+  pCommand.command('snapshot-stars')
+    .description(`Record today's stargazer count (GitHub GraphQL stargazerCount) for every repo that belongs
+to a collection into the sys_repo_star_snapshots table. Idempotent: re-running on the same day
+refreshes the same rows.`)
+    .option('--dry-run', 'Fetch stargazer counts but skip all database writes, printing what would be written.', false)
+    .option<number>(
+      '--batch-size <number>',
+      `How many repos to look up per GraphQL request (via field aliases). Default: ${DEFAULT_SNAPSHOT_BATCH_SIZE}.`,
+      (value) => {
+        const parsed = parseInt(value, 10);
+        if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_SNAPSHOT_BATCH_SIZE) {
+          throw new InvalidArgumentError(`Batch size must be an integer between 1 and ${MAX_SNAPSHOT_BATCH_SIZE}.`);
+        }
+        return parsed;
+      },
+      DEFAULT_SNAPSHOT_BATCH_SIZE
+    )
+    .option(
+      '--repos [string]',
+      `Comma-separated list of "{owner}/{repo}" or "{repoId}:{owner}/{repo}" entries to snapshot instead of
+loading the collection repos from the database. Combined with --dry-run, this lets the command run
+without a DATABASE_URL. For example: --repos=41986369:pingcap/tidb,vuejs/core`
+    )
+    .option(
+      '--snapshot-day [string]',
+      'The UTC day (YYYY-MM-DD) to record the snapshots under. Default: today (UTC).'
+    )
+    .action(async (options: Options) => {
+      try {
+        await snapshotStars(config, logger, options);
+      } catch (err) {
+        logger.error(err, `⭐ Failed to snapshot stargazer counts.`);
+        // The pino transport worker can lose logs when the process exits right
+        // after a synchronous failure, so mirror the fatal error on stderr.
+        console.error('Failed to snapshot stargazer counts:', err);
+        process.exitCode = 1;
+      }
+    });
+}
+
+export function resolveSnapshotDay(snapshotDay?: string): string {
+  if (!snapshotDay) {
+    return DateTime.utc().toFormat('yyyy-LL-dd');
+  }
+
+  const parsed = DateTime.fromISO(snapshotDay, {zone: 'utc'});
+  if (!parsed.isValid || parsed.toFormat('yyyy-LL-dd') !== snapshotDay) {
+    throw new Error(`Invalid --snapshot-day: ${snapshotDay}, expected the YYYY-MM-DD format.`);
+  }
+
+  return snapshotDay;
+}
+
+export function parseReposArg(reposArg: string): TargetRepo[] {
+  return reposArg
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      const matched = /^(?:(\d+):)?(.+)$/.exec(entry);
+      if (!matched) {
+        throw new Error(`Invalid --repos entry: ${entry}, expected "{owner}/{repo}" or "{repoId}:{owner}/{repo}".`);
+      }
+      return {
+        repoId: matched[1] ? Number(matched[1]) : null,
+        repoName: matched[2],
+      };
+    });
+}
+
+async function loadCollectionRepos(prisma: PrismaClient): Promise<TargetRepo[]> {
+  const rows = await prisma.$queryRawUnsafe<Array<{repoId: number | bigint, repoName: string}>>(COLLECTION_REPOS_SQL);
+
+  // A repo can appear in many collections (and, when the github_repos row is
+  // missing, under different stale names): keep one entry per repo id.
+  const reposById = new Map<number, TargetRepo>();
+  for (const row of rows) {
+    const repoId = Number(row.repoId);
+    if (!reposById.has(repoId)) {
+      reposById.set(repoId, {repoId, repoName: row.repoName});
+    }
+  }
+
+  return [...reposById.values()];
+}
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export async function snapshotStars(config: AppConfig, logger: Logger, options: Options) {
+  const {dryRun, batchSize, repos: reposArg} = options;
+  const snapshotDay = resolveSnapshotDay(options.snapshotDay);
+
+  // Init the GitHub helper.
+  const octokitPool = createOctokitPool(logger, config.GITHUB_ACCESS_TOKENS);
+  const githubHelper = new GitHubHelper(logger, octokitPool);
+
+  // The database is needed to load the repo set (unless --repos is given) and to
+  // write the snapshots (unless --dry-run is given).
+  let prisma: PrismaClient | null = null;
+  let snapshotDao: RepoStarSnapshotDao | null = null;
+  if (!reposArg || !dryRun) {
+    if (!config.DATABASE_URL) {
+      throw new Error(`DATABASE_URL is required (only "--dry-run --repos <...>" can run without it).`);
+    }
+    prisma = new PrismaClient();
+    snapshotDao = new RepoStarSnapshotDao(logger, prisma);
+  }
+
+  // Load the target repos.
+  const targetRepos = reposArg ? parseReposArg(reposArg) : await loadCollectionRepos(prisma!);
+  logger.info(`⭐ Begin to snapshot stargazer counts for ${targetRepos.length} repos on ${snapshotDay} (dryRun=${dryRun}).`);
+
+  // Make sure the snapshot table exists before the first write.
+  if (snapshotDao !== null && !dryRun) {
+    await snapshotDao.ensureTable(config.CONFIGS_PATH);
+  }
+
+  const counters = {processed: 0, written: 0, failed: 0};
+  // NOTE: each batch is wrapped in an object because async.queue (inside
+  // processInBatch) treats a pushed array as a list of individual tasks.
+  const batches = chunkArray(targetRepos, batchSize).map((repos) => ({repos}));
+  await processInBatch<{repos: TargetRepo[]}>(batches, octokitPool.max, async ({repos: batch}) => {
+    try {
+      const {nodes, missing} = await githubHelper.batchGetRepoStarCounts(batch.map((repo) => repo.repoName));
+      const retrievedAt = new Date();
+
+      const snapshots: RepoStarSnapshot[] = [];
+      for (const repo of batch) {
+        const node = nodes.get(repo.repoName);
+        if (!node) {
+          continue;
+        }
+
+        if (repo.repoId !== null && repo.repoId !== node.databaseId) {
+          logger.warn(`⭐ Repo ${repo.repoName} resolved to ${node.nameWithOwner} (id=${node.databaseId}), ` +
+            `but the collection references id=${repo.repoId}, keeping the collection repo id.`);
+        }
+
+        const snapshot: RepoStarSnapshot = {
+          repoId: repo.repoId ?? node.databaseId,
+          snapshotDay,
+          stargazerCount: node.stargazerCount,
+          forksCount: typeof node.forkCount === 'number' ? node.forkCount : null,
+          retrievedAt,
+          source: SNAPSHOT_SOURCE_GITHUB_GRAPHQL,
+        };
+
+        if (dryRun) {
+          logger.info(`⭐ [dry-run] Would write snapshot: repo_id=${snapshot.repoId} repo_name=${repo.repoName} ` +
+            `snapshot_day=${snapshot.snapshotDay} stargazer_count=${snapshot.stargazerCount} forks_count=${snapshot.forksCount}`);
+        }
+
+        snapshots.push(snapshot);
+      }
+
+      for (const repoName of missing) {
+        logger.warn(`⭐ Skip repo ${repoName}: not resolvable on GitHub (deleted, private or renamed without redirect).`);
+      }
+
+      if (!dryRun) {
+        await snapshotDao!.upsertSnapshots(snapshots);
+      }
+
+      counters.processed += batch.length;
+      counters.written += snapshots.length;
+      counters.failed += batch.length - snapshots.length;
+    } catch (err) {
+      counters.processed += batch.length;
+      counters.failed += batch.length;
+      logger.error(err, `⭐ Failed to snapshot a batch of ${batch.length} repos (first: ${batch[0]?.repoName}).`);
+    }
+  });
+
+  logger.info(`⭐ Snapshot summary: snapshot_day=${snapshotDay} repos_processed=${counters.processed} ` +
+    `snapshots_${dryRun ? 'planned' : 'written'}=${counters.written} failures=${counters.failed}` +
+    `${dryRun ? ' (dry-run, no database writes)' : ''}`);
+
+  await prisma?.$disconnect();
+
+  if (counters.processed > 0 && counters.written === 0) {
+    throw new Error(`All ${counters.processed} repos failed to snapshot, see the logs above.`);
+  }
+}

--- a/packages/sync-github-data/src/dao/repo-star-snapshot-dao.ts
+++ b/packages/sync-github-data/src/dao/repo-star-snapshot-dao.ts
@@ -1,0 +1,60 @@
+import {Prisma, PrismaClient} from '@prisma/client';
+import * as fs from "fs";
+import path from "path";
+import {Logger} from "pino";
+
+export const REPO_STAR_SNAPSHOTS_TABLE = 'sys_repo_star_snapshots';
+
+export interface RepoStarSnapshot {
+  repoId: number;
+  // The UTC day the snapshot belongs to, formatted as `YYYY-MM-DD`.
+  snapshotDay: string;
+  stargazerCount: number;
+  forksCount: number | null;
+  retrievedAt: Date;
+  source: string;
+}
+
+export class RepoStarSnapshotDao {
+
+  constructor(readonly logger: Logger, readonly prisma: PrismaClient) {}
+
+  /**
+   * The table DDL lives in `configs/materialized_views/sys_repo_star_snapshots/ddl.sql`
+   * (a `CREATE TABLE IF NOT EXISTS` statement), so the first run can bootstrap the
+   * table by itself while the DDL stays single-sourced in the configs directory.
+   */
+  async ensureTable(configsPath: string): Promise<void> {
+    const ddlPath = path.join(configsPath, 'materialized_views', REPO_STAR_SNAPSHOTS_TABLE, 'ddl.sql');
+    const ddl = fs.readFileSync(ddlPath, 'utf-8');
+    await this.prisma.$executeRawUnsafe(ddl);
+    this.logger.debug(`Ensured table ${REPO_STAR_SNAPSHOTS_TABLE} exists.`);
+  }
+
+  // Idempotent by design: re-running the snapshot job on the same day only
+  // refreshes the same (repo_id, snapshot_day) rows.
+  async upsertSnapshots(snapshots: RepoStarSnapshot[]): Promise<number> {
+    if (!Array.isArray(snapshots) || snapshots.length === 0) {
+      return 0;
+    }
+
+    const affectedRows = await this.prisma.$executeRaw`
+        INSERT INTO sys_repo_star_snapshots (repo_id, snapshot_day, stargazer_count, forks_count, retrieved_at, source)
+        VALUES ${Prisma.join(snapshots.map(snapshot => Prisma.sql`(
+        ${snapshot.repoId}, ${snapshot.snapshotDay}, ${snapshot.stargazerCount}, ${snapshot.forksCount},
+        ${snapshot.retrievedAt}, ${snapshot.source}
+      )`))}
+        ON DUPLICATE KEY UPDATE stargazer_count = VALUES(stargazer_count),
+                                forks_count     = VALUES(forks_count),
+                                retrieved_at    = VALUES(retrieved_at),
+                                source          = VALUES(source);
+    `;
+
+    if (affectedRows > 0) {
+      this.logger.info(`💾 Bulk upsert ${snapshots.length} repo star snapshots.`);
+    }
+
+    return affectedRows;
+  }
+
+}

--- a/packages/sync-github-data/src/env.ts
+++ b/packages/sync-github-data/src/env.ts
@@ -2,14 +2,17 @@ import {resolve} from "path";
 
 export interface AppConfig {
   CONFIGS_PATH: string;
-  DATABASE_URL: string;
+  // Optional at load time so that `repos snapshot-stars --dry-run --repos <...>`
+  // can run without database credentials; every command that touches the
+  // database still requires it (Prisma reads it from the environment).
+  DATABASE_URL?: string;
   GITHUB_ACCESS_TOKENS: string[];
   LOG_LEVEL: string;
 }
 
 export const SyncGitHubDataEnvSchema = {
   type: 'object',
-  required: ['DATABASE_URL', 'GITHUB_ACCESS_TOKENS'],
+  required: ['GITHUB_ACCESS_TOKENS'],
   properties: {
     CONFIGS_PATH: {
       type: 'string',

--- a/packages/sync-github-data/src/index.ts
+++ b/packages/sync-github-data/src/index.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+import {initSnapshotStarsCommand} from "@commands/repos/snapshot-stars";
 import {initSyncReposInBatchCommand} from "@commands/repos/sync-in-batch";
 import {initSyncUsersInBatchCommand} from "@commands/users/sync-in-batch";
 import {AppConfig, SyncGitHubDataEnvSchema} from "@env";
@@ -20,6 +21,7 @@ async function main() {
 
   const reposCommand = program.command('repos');
   initSyncReposInBatchCommand(reposCommand, config, logger);
+  initSnapshotStarsCommand(reposCommand, config, logger);
 
   const usersCommand = program.command('users');
   initSyncUsersInBatchCommand(usersCommand, config, logger);

--- a/packages/sync-github-data/src/libs/github/helper.ts
+++ b/packages/sync-github-data/src/libs/github/helper.ts
@@ -1,4 +1,4 @@
-import {GitHubRepoNode, GitHubUserNode} from "@typings/github";
+import {GitHubRepoNode, GitHubRepoStarCountNode, GitHubUserNode} from "@typings/github";
 import {Pool as GenericPool} from "generic-pool";
 import {DateTime} from "luxon";
 import {Octokit} from "octokit";
@@ -405,15 +405,101 @@ export class GitHubHelper {
     return res.node;
   }
 
+  /**
+   * Fetch the current stargazer / fork totals for multiple repos in a single GraphQL
+   * request by aliasing one `repository(owner:..., name:...)` field per repo
+   * (~10 repos per rate-limit point).
+   *
+   * Repos that no longer resolve (deleted, made private, renamed without redirect)
+   * are reported in `missing` instead of failing the whole batch: GitHub answers such
+   * aliases with `null` plus a NOT_FOUND error, and octokit raises a GraphqlResponseError
+   * that still carries the partial data for the aliases that did resolve.
+   *
+   * @param repoNames Repo names in `{owner}/{repo}` format.
+   * @returns Resolved nodes keyed by the REQUESTED repo name (renames follow the
+   *          redirect, so `nameWithOwner` in the node may differ), plus the list of
+   *          repo names that could not be resolved.
+   */
+  async batchGetRepoStarCounts(repoNames: string[]): Promise<{nodes: Map<string, GitHubRepoStarCountNode>, missing: string[]}> {
+    const nodes = new Map<string, GitHubRepoStarCountNode>();
+    const missing: string[] = [];
+
+    const aliases: Array<[alias: string, repoName: string]> = [];
+    const fields: string[] = [];
+    repoNames.forEach((repoName, index) => {
+      const parts = repoName.split('/');
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        this.logger.warn(`⭐ Skip malformed repo name: ${repoName}.`);
+        missing.push(repoName);
+        return;
+      }
+
+      const alias = `repo${index}`;
+      aliases.push([alias, repoName]);
+      // JSON.stringify produces a valid, escaped GraphQL string literal.
+      fields.push(`${alias}: repository(owner: ${JSON.stringify(parts[0])}, name: ${JSON.stringify(parts[1])}) {
+        databaseId
+        nameWithOwner
+        stargazerCount
+        forkCount
+      }`);
+    });
+
+    if (fields.length === 0) {
+      return {nodes, missing};
+    }
+
+    const gql = `
+      query {
+        ${fields.join('\n')}
+        rateLimit {
+          limit
+          cost
+          remaining
+          resetAt
+        }
+      }
+    `;
+
+    let res: any;
+    try {
+      res = await this.queryWithGQL<any>(gql);
+    } catch (err: any) {
+      if (err?.data) {
+        // Partial response: keep what resolved, the unresolved aliases fall through
+        // to the `missing` list below.
+        this.logger.warn(`⭐ Some repos in the batch could not be resolved: ${err.message}`);
+        res = err.data;
+      } else {
+        throw err;
+      }
+    }
+
+    for (const [alias, repoName] of aliases) {
+      const node = res?.[alias];
+      if (node && typeof node.databaseId === 'number' && typeof node.stargazerCount === 'number') {
+        nodes.set(repoName, node);
+      } else {
+        missing.push(repoName);
+      }
+    }
+
+    return {nodes, missing};
+  }
+
   async getUserRepoIds(login: string): Promise<number[]> {
     return await this.octokitPool.use(async (octokit) => {
-      const repoIterator = await octokit.paginate.iterator(octokit.rest.repos.listForUser, {
+      // NOTE: the `as any` casts work around a fresh-install type breakage:
+      // octokit ^2 resolves plugins bundling different @octokit/types majors
+      // (9 vs 10), whose paginate overloads reject each other. Runtime behavior
+      // is unchanged.
+      const repoIterator = await octokit.paginate.iterator(octokit.rest.repos.listForUser as any, {
         username: login,
       });
 
       const repoIds: any[] = [];
       for await (const repo of repoIterator) {
-        repo.data.forEach((r) => {
+        repo.data.forEach((r: any) => {
           repoIds.push(r.id);
         });
       }
@@ -423,13 +509,14 @@ export class GitHubHelper {
 
   async getOrgRepoIds(login: string): Promise<number[]> {
     return await this.octokitPool.use(async (octokit) => {
-      const repoIterator = await octokit.paginate.iterator(octokit.rest.repos.listForOrg, {
+      // NOTE: see getUserRepoIds for why the `as any` casts are needed.
+      const repoIterator = await octokit.paginate.iterator(octokit.rest.repos.listForOrg as any, {
         org: login,
       });
 
       const repoIds: any[] = [];
       for await (const repo of repoIterator) {
-        repo.data.forEach((r) => {
+        repo.data.forEach((r: any) => {
           repoIds.push(r.id);
         });
       }

--- a/packages/sync-github-data/src/typings/github.ts
+++ b/packages/sync-github-data/src/typings/github.ts
@@ -109,3 +109,10 @@ export interface GitHubOrganizationNode {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface GitHubRepoStarCountNode {
+  databaseId: number;
+  nameWithOwner: string;
+  stargazerCount: number;
+  forkCount: number;
+}


### PR DESCRIPTION
Star rankings can no longer be derived from `WatchEvent` flow, and per-repo star history is not recoverable from any public archive. The one authoritative signal that still works is the GraphQL `stargazerCount` total — so future rankings have to be built from **snapshot deltas**, which only exist if we start recording them. **Every day not captured is lost forever**, which is why this is worth landing before the historical backfill work.

## What it does

New `repos snapshot-stars` command: loads the distinct repos of all active collections, fetches `stargazerCount`/`forkCount` in batched GraphQL requests via field aliases, and upserts into a new `sys_repo_star_snapshots` table.

Keyed on a real `(repo_id, snapshot_day)` primary key with `ON DUPLICATE KEY UPDATE`, so re-running on the same day is safe. Snapshots deliberately do **not** go into `github_events`, which has no unique key and where a re-run would silently double-insert.

## Verified against production

Table created on the live TiDB cluster, then a real full run:

```
Snapshot summary: snapshot_day=2026-09-01 repos_processed=2172
                  snapshots_written=2142 failures=30
```

The 30 failures are deleted/renamed/private repos; they are logged individually and skipped via the partial GraphQL response rather than aborting the run.

**Idempotency:** re-ran 5 repos on the same day afterwards — table still holds 2142 rows, and `total_rows == unique_keys == 2142`. No duplicates.

**Cost:** measured 5 rate-limit points per 50 repos, so the full 2,446-repo run costs **~244 points — 4% of one token's hourly GraphQL budget**. It comfortably fits the built-in `GITHUB_TOKEN` if no PAT is configured.

**The numbers show exactly why this matters** — snapshot vs what our event-derived data believes:

| repo | snapshot (truth) | our event-derived total | gap |
|---|---|---|---|
| langchain-ai/langchain | 145,390 | 116,764 | **-19.6%** |
| cline/cline | 67,252 | 49,051 | **-26.8%** |

## Also included

- `--dry-run` prints what would be written without touching the database, and `--dry-run --repos <owner/name,...>` runs without `DATABASE_URL` at all.
- Table DDL in `configs/materialized_views/sys_repo_star_snapshots/` (`CREATE TABLE IF NOT EXISTS`, applied before the first write) with provenance columns (`retrieved_at`, `source`), plus a Prisma model.
- Daily cron workflow at 00:23 UTC + manual dispatch, with required secrets documented.

## Note for whoever enables the cron

The workflow needs a `DATABASE_URL` repository secret in Prisma `mysql://` form with `sslaccept=strict` (TiDB Serverless needs it; the `@tidbcloud/serverless` driver used elsewhere does not). Until that secret exists the scheduled run will fail — today's snapshot is already captured manually, so there is no gap yet, but the clock is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)