### PR TITLE
sync-github-data: force TLS on the snapshot job's TiDB connection

### DIFF
--- a/packages/sync-github-data/src/commands/repos/snapshot-stars.ts
+++ b/packages/sync-github-data/src/commands/repos/snapshot-stars.ts
@@ -155,7 +155,14 @@ export async function snapshotStars(config: AppConfig, logger: Logger, options: 
     if (!config.DATABASE_URL) {
       throw new Error(`DATABASE_URL is required (only "--dry-run --repos <...>" can run without it).`);
     }
-    prisma = new PrismaClient();
+    // TiDB Serverless rejects unencrypted connections, and Prisma only negotiates
+    // TLS when the URL asks for it. The shared DATABASE_URL secret is also read by
+    // jobs using the @tidbcloud/serverless driver, which needs no such parameter,
+    // so the secret cannot simply be rewritten — normalize here instead of
+    // depending on its exact format.
+    prisma = new PrismaClient({
+      datasources: { db: { url: withTiDBSsl(config.DATABASE_URL) } },
+    });
     snapshotDao = new RepoStarSnapshotDao(logger, prisma);
   }
 
@@ -233,4 +240,16 @@ export async function snapshotStars(config: AppConfig, logger: Logger, options: 
   if (counters.processed > 0 && counters.written === 0) {
     throw new Error(`All ${counters.processed} repos failed to snapshot, see the logs above.`);
   }
+}
+
+/**
+ * Ensure a TiDB Serverless connection string carries `sslaccept=strict`, which
+ * Prisma needs to negotiate TLS, and accept the `tidb://` scheme some deployed
+ * configs use.
+ */
+export function withTiDBSsl(url: string): string {
+  if (!url) return url;
+  const normalized = url.replace(/^tidb:\/\//, 'mysql://');
+  if (/[?&]sslaccept=/.test(normalized)) return normalized;
+  return normalized + (normalized.includes('?') ? '&' : '?') + 'sslaccept=strict';
 }


### PR DESCRIPTION
The first scheduled run of `daily-star-snapshots` (added in #3116) failed:

```
ERROR HY000 (1105): Connections using insecure transport are prohibited
```

TiDB Serverless rejects unencrypted connections, and Prisma only negotiates TLS when the URL asks for it — but the repository's shared `DATABASE_URL` secret has no `sslaccept=strict`.

That secret is also consumed by jobs using the `@tidbcloud/serverless` driver, which needs no such parameter, so **rewriting the secret would risk those jobs**. Normalizing in code is the safer fix, and it also makes the command work regardless of how any given deployment writes the URL.

`withTiDBSsl()` appends `sslaccept=strict` when absent and maps the `tidb://` scheme some deployed configs use onto `mysql://`. Verified against all four shapes:

| input | output |
|---|---|
| `mysql://…/db` | `…/db?sslaccept=strict` |
| `tidb://…/db` | `mysql://…/db?sslaccept=strict` |
| `…/db?sslaccept=strict` | unchanged |
| `…/db?foo=1` | `…/db?foo=1&sslaccept=strict` |

Today's snapshot was already captured by a manual run, so no data point has been lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)