### PR TITLE
etl: poll every /events page at 2 req/s; quarantine dead tokens in sync-github-data

### DIFF
--- a/etl/config/initializers/fetch_event.rb
+++ b/etl/config/initializers/fetch_event.rb
@@ -69,14 +69,15 @@ class FetchEvent
     url = url_for(page)
     resp = nil
     begin
-      Retryable.retryable(tries: 5, on: [Timeout::Error, Net::OpenTimeout, OpenURI::HTTPError]) do
-        resp = URI.open(url,
-          open_timeout: 600,
-          read_timeout: 600,
-          'user-agent' => 'ossinsight.io',
-          'Authorization' => 'token ' + token
-        )
-      end
+      # No in-request retry and short timeouts: each page is polled again
+      # half a second later by Realtime, and that next poll IS the retry. The
+      # old 600s timeouts could pin a page for ten minutes on one hung socket.
+      resp = URI.open(url,
+        open_timeout: 5,
+        read_timeout: 15,
+        'user-agent' => 'ossinsight.io',
+        'Authorization' => 'token ' + token
+      )
     rescue OpenURI::HTTPError => e
       # e.message is the real status line (e.g. "403 Forbidden"). This used to
       # print "skip 404 file" for ANY HTTP error, which hid rate limits and
@@ -101,10 +102,8 @@ class FetchEvent
 
       puts "HTTP error (#{status}) fetching #{url} | remaining=#{remaining} | body=#{body}"
       nil
-    rescue Timeout::Error, Net::OpenTimeout => e
-      # Contain post-retry timeouts per page so one bad page does not discard
-      # the events already fetched from the other pages this iteration.
-      puts "#{e.class} after retries fetching #{url}"
+    rescue Timeout::Error, Net::OpenTimeout, Errno::ECONNRESET, EOFError, SocketError => e
+      puts "#{e.class} fetching #{url}"
       nil
     else
       record_rate_limit(resp)
@@ -124,6 +123,19 @@ class FetchEvent
     @rate_limit_reset_at = reset.to_i if reset
   end
 
+  # One page of the feed as github_events rows, or nil when the request
+  # failed. Rate-limit and rejection state is updated as a side effect; the
+  # caller (Realtime) decides what that means for the token.
+  def fetch(page)
+    json = get_response(page)
+    return nil unless json
+
+    Yajl::Parser.parse(json).map { |event| parse_event(event) }
+  end
+
+  # Sequential fetch-then-write of all pages with one token. Realtime no
+  # longer uses this (it polls pages concurrently and writes on its own
+  # thread); kept for one-off runs from a console.
   def run
     new_events = []
     fetched_pages = []
@@ -133,10 +145,10 @@ class FetchEvent
         break
       end
 
-      json = get_response(page)
-      next unless json
+      events = fetch(page)
+      next unless events
 
-      new_events.concat(Yajl::Parser.parse(json).map { |event| parse_event(event) })
+      new_events.concat(events)
       fetched_pages << page
     end
 

--- a/etl/config/initializers/realtime.rb
+++ b/etl/config/initializers/realtime.rb
@@ -1,93 +1,391 @@
 require_relative './fetch_event'
 
+# Polls the GitHub /events firehose and writes whatever it captures.
+#
+# Why it is shaped this way (all measured 2026-09-01; partition facts are in
+# FetchEvent):
+#
+#   * The feed is an unordered sample, not a sliding window. Two requests in
+#     the same instant return the same body; requests one second apart share
+#     nothing. Distinct events captured therefore scale with request cadence.
+#     The one collector known to capture the full stream (ClickHouse's
+#     gharchive importer) polls every page twice a second, and times each
+#     poll from when the request was SENT, not from when the response landed.
+#   * A single sequential loop cannot get there: page 2 waits for page 1's
+#     round trip and for the database write, so one process managed ~0.67
+#     polls/s/page and the second copy (gh_realtime2) only lifted the pair to
+#     ~1.3. That is where the measured 84% capture rate came from.
+#
+# So every page gets its own POLL_INTERVAL clock (PageSchedule) and a few
+# sender threads that take turns on it: GitHub answers page 1 in ~0.5s but
+# pages 2-3 in ~1.4s, so a single thread per page only managed 0.7 sends/s
+# there (first deploy, 2026-09-01). One writer on the main Rails connection
+# does deduplication and inserts. Senders never touch ActiveRecord; the
+# writer never touches HTTP. The writer is the only thread that consults
+# EventLog, which is what keeps the no-unique-key github_events table free
+# of same-instant duplicates.
+#
+# Budget: 3 pages x 2 req/s = 21,600 req/h. Seven 5,000 req/h tokens give
+# 35,000, so ONE process fits with ~60% headroom and two do not (43,200).
+# gh_realtime2 is therefore disabled; do not start a second instance.
 class Realtime
-  attr_reader :tokens, :per_page, :tokens_count
+  attr_reader :tokens, :tokens_count
 
-  # The /events feed shares no event ids between polls even one second apart
-  # (measured 2026-09-01), so distinct events captured scale with the request
-  # budget and the hourly rate limit is the binding constraint. Each iteration
-  # now costs 3 requests instead of 1 (offsets 1-300 rather than the Push-only
-  # first page), so the loop must notice throttling instead of spinning on it.
-  #
-  # When every token is exhausted, sleep until the earliest reset rather than
-  # hammering GitHub with 403s, which risks secondary rate limiting on top of
-  # the primary one.
+  # Seconds between request sends on each page, measured from the send.
+  POLL_INTERVAL = 0.5
+  PAGES = FetchEvent::MAX_PAGES
+  # Threads sharing one page's schedule, i.e. requests that may be in flight
+  # for that page at once. Covers ~2s of GitHub latency at 2 sends/s.
+  SENDERS_PER_PAGE = 4
   MAX_BACKOFF_SECONDS = 60
+  STATS_EVERY = 60
+  # Rows per INSERT. github_events has 32 columns, so this is ~50KB of SQL.
+  WRITE_SLICE = 100
+  # Pages per write cycle. Bounds the id list handed to EventLog and the
+  # memory held while TiDB is slow.
+  MAX_PAGES_PER_WRITE = 30
+  # Fetched pages waiting for the writer. When TiDB stalls, fetchers block on
+  # push instead of growing memory without bound; depth is in the stats line.
+  MAX_QUEUED_PAGES = 200
+  # EventLog only remembers ids inserted in the last 30 minutes (see clean!),
+  # but the feed re-serves events that are hours or days old: measured
+  # 2026-09-01, a third of what a poll returned was over 24h old and 93% of
+  # those were already in github_events. Events older than this are checked
+  # against github_events itself before insert. Keep it under clean!'s
+  # window so the two guards overlap.
+  RECHECK_OLDER_THAN_SECONDS = 25 * 60
 
   def initialize(tokens, per_page)
     raise "You need to create github token here: https://github.com/settings/tokens, and set GITHUB_TOKEN env." if tokens.blank?
     @tokens = tokens
+    @tokens_count = tokens.size
+    # Kept for call-site compatibility; FetchEvent pins per_page itself.
     @per_page = per_page
-    @tokens_count = @tokens.size
-    # token => Time at which its hourly window resets, for tokens known to be spent.
+    @lock = Mutex.new
+    @cursor = 0
+    # token => epoch second at which its hourly window resets.
     @exhausted_until = {}
     # Credentials GitHub refuses outright (suspended account, revoked token).
-    # These never recover on their own, so they are dropped for the process
-    # lifetime rather than retried into every poll.
+    # Never recover on their own, so dropped for the process lifetime.
     @rejected = {}
+    @queue = SizedQueue.new(MAX_QUEUED_PAGES)
   end
 
   def run
-    loop do
-      if usable_token_count.zero?
-        puts "FATAL: all #{tokens_count} GitHub tokens were rejected (suspended or revoked); ingestion cannot continue until they are replaced"
-        sleep MAX_BACKOFF_SECONDS
-        next
-      end
-
-      token = next_available_token
-      if token.nil?
-        wait = backoff_seconds
-        puts "all #{tokens_count} token(s) rate limited; sleeping #{wait}s"
-        sleep wait
-        next
-      end
-
-      begin
-        fetcher = FetchEvent.new(per_page, token)
-        fetcher.run
-        if fetcher.token_rejected?
-          @rejected[token] = true
-          puts "token …#{token[-4..]} rejected by GitHub (suspended or revoked); #{usable_token_count} of #{tokens_count} still usable"
-        elsif fetcher.rate_limited?
-          @exhausted_until[token] = Time.now.to_i + (fetcher.seconds_until_reset || MAX_BACKOFF_SECONDS)
-        else
-          @exhausted_until.delete(token)
+    $stdout.sync = true
+    puts "realtime: #{PAGES} pages x #{SENDERS_PER_PAGE} senders, one send per #{POLL_INTERVAL}s per page, #{tokens_count} tokens, writer on main thread"
+    (1..PAGES).each do |page|
+      schedule = PageSchedule.new(POLL_INTERVAL)
+      stats = PageStats.new(page)
+      SENDERS_PER_PAGE.times do |i|
+        Thread.new do
+          Thread.current.name = "poll-#{page}-#{i}"
+          Thread.current.report_on_exception = true
+          poll_forever(page, schedule, stats)
         end
-      rescue
-        ActiveRecord::Base.connection.reconnect!
-        puts $!
       end
     end
+    write_forever
   end
 
+  # EventLog is the only duplicate guard. The feed re-serves events well after
+  # they first appear (a single page spans days of created_at), and polling
+  # six times a second sees each one more often, so keep ids longer than the
+  # old five minutes. ~10k rows/min at 30 minutes is a few hundred thousand
+  # rows; lookups are by primary key so size barely matters.
   def self.clean!
-    EventLog.where("created_at <= ?", 5.minutes.ago).limit(100000).delete_all
+    EventLog.where("created_at <= ?", 30.minutes.ago).limit(100000).delete_all
   end
 
   private
 
-  # A token whose window is known to have reset, preferring an unseen one.
-  def next_available_token
-    now = Time.now.to_i
-    available = tokens.reject { |t| @rejected[t] || (@exhausted_until[t] || 0) > now }
-    return nil if available.empty?
+  # One sender, forever. Every poll is independent: a failed poll is not
+  # retried, the next slot on this page's schedule is the retry.
+  def poll_forever(page, schedule, stats)
+    loop do
+      begin
+        schedule.wait_for_slot
+        token = checkout_token
+        if token.nil?
+          stats.flush_if_due(usable_token_count)
+          sleep idle_wait
+          next
+        end
 
-    available[rand(available.size)]
+        fetcher = FetchEvent.new(FetchEvent::PER_PAGE, token)
+        events = fetcher.fetch(page)
+        settle_token(token, fetcher)
+
+        if events
+          stats.ok(events.map { |e| e['id'].to_i })
+          @queue.push([page, events])
+        else
+          stats.failed
+        end
+        stats.flush_if_due(usable_token_count)
+      rescue => e
+        puts "page #{page}: #{e.class}: #{e.message}"
+        sleep 1
+      end
+    end
   end
 
-  # Credentials not permanently refused by GitHub.
+  # Main thread. Merges whatever the pollers have queued, dedups across pages
+  # and against EventLog, inserts. One writer means the EventLog check and
+  # the insert cannot race each other.
+  def write_forever
+    stats = WriterStats.new
+    loop do
+      begin
+        pages = drain_queue
+        events = pages.flat_map { |_, evs| evs }.uniq { |e| e['id'].to_i }
+        started = monotonic
+        inserted, already_stored = write_with_retry(events)
+        stats.record(pages.size, events.size, inserted, already_stored, @queue.size, monotonic - started)
+        stats.flush_if_due
+      rescue => e
+        puts "writer: #{e.class}: #{e.message}"
+        sleep 1
+      end
+    end
+  end
+
+  def drain_queue
+    pages = [@queue.pop]
+    pages << @queue.pop while pages.size < MAX_PAGES_PER_WRITE && !@queue.empty?
+    pages
+  end
+
+  # Returns [inserted, already_stored].
+  def write(events)
+    return [0, 0] if events.empty?
+
+    ids = events.map { |e| e['id'].to_i }
+    existing = EventLog.where(id: ids).pluck(:id).to_set
+    fresh = events.reject { |e| existing.include?(e['id'].to_i) }
+    stored = stored_ids(fresh.select { |e| older_than_window?(e) })
+    fresh = fresh.reject { |e| stored.include?(e['id'].to_i) } unless stored.empty?
+    fresh.each_slice(WRITE_SLICE) do |es|
+      EventLog.insert_all(es.map { |e| { id: e['id'], created_at: Time.now } })
+      GithubEvent.insert_all(es)
+    end
+    [fresh.size, stored.size]
+  end
+
+  def older_than_window?(event)
+    Time.iso8601(event['created_at']) < Time.now - RECHECK_OLDER_THAN_SECONDS
+  rescue ArgumentError, TypeError
+    true
+  end
+
+  # Ids among `events` that github_events already holds. github_events is
+  # LIST-partitioned by type with a local index on id, so one predicate per
+  # type lets TiDB prune each branch to a single partition; UNION ALL keeps
+  # it to one round trip.
+  def stored_ids(events)
+    return Set.new if events.empty?
+
+    conn = GithubEvent.connection
+    sql = events.group_by { |e| e['type'] }.map do |type, es|
+      "SELECT id FROM github_events WHERE type = #{conn.quote(type)} AND id IN (#{es.map { |e| e['id'].to_i }.uniq.join(',')})"
+    end.join(' UNION ALL ')
+    conn.select_values(sql).map(&:to_i).to_set
+  end
+
+  # A dropped connection is the common failure; reconnect and try once more.
+  # The retry re-checks EventLog, so slices that already landed are skipped.
+  def write_with_retry(events)
+    write(events)
+  rescue => e
+    puts "writer: #{e.class}: #{e.message}; reconnecting and retrying once"
+    (ActiveRecord::Base.connection.reconnect! rescue nil)
+    begin
+      write(events)
+    rescue => again
+      puts "writer: retry failed (#{again.class}: #{again.message}); dropping #{events.size} events"
+      [0, 0]
+    end
+  end
+
+  # Round-robin over tokens that are neither rejected nor inside a spent
+  # window, so the 6 req/s spread evenly across the pool.
+  def checkout_token
+    @lock.synchronize do
+      now = Time.now.to_i
+      tokens_count.times do
+        t = tokens[@cursor]
+        @cursor = (@cursor + 1) % tokens_count
+        return t unless @rejected[t] || (@exhausted_until[t] || 0) > now
+      end
+      nil
+    end
+  end
+
+  def settle_token(token, fetcher)
+    @lock.synchronize do
+      if fetcher.token_rejected?
+        unless @rejected[token]
+          @rejected[token] = true
+          puts "token …#{token[-4..]} rejected by GitHub (suspended or revoked); #{tokens.count { |t| !@rejected[t] }} of #{tokens_count} still usable"
+        end
+      elsif fetcher.rate_limited?
+        @exhausted_until[token] = Time.now.to_i + (fetcher.seconds_until_reset || MAX_BACKOFF_SECONDS)
+      else
+        @exhausted_until.delete(token)
+      end
+    end
+  end
+
   def usable_token_count
-    tokens.count { |t| !@rejected[t] }
+    @lock.synchronize { tokens.count { |t| !@rejected[t] } }
   end
 
-  # Time until the earliest token resets, clamped so a bad reset header cannot
-  # stall ingestion for an hour.
+  def idle_wait
+    if usable_token_count.zero?
+      puts "FATAL: all #{tokens_count} GitHub tokens were rejected (suspended or revoked); ingestion cannot continue until they are replaced"
+      return MAX_BACKOFF_SECONDS
+    end
+    wait = backoff_seconds
+    puts "all usable tokens rate limited; sleeping #{wait}s"
+    wait
+  end
+
+  # Time until the earliest token resets, clamped so a bad reset header
+  # cannot stall a page for an hour.
   def backoff_seconds
-    now = Time.now.to_i
-    soonest = @exhausted_until.values.min
+    soonest = @lock.synchronize { @exhausted_until.values.min }
     return MAX_BACKOFF_SECONDS if soonest.nil?
 
-    [[soonest - now, 1].max, MAX_BACKOFF_SECONDS].min
+    [[soonest - Time.now.to_i, 1].max, MAX_BACKOFF_SECONDS].min
+  end
+
+  def monotonic
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  # Hands out send times INTERVAL apart to whichever sender asks next, so a
+  # page is polled on a fixed cadence no matter how long each response takes.
+  # If every sender is busy and the clock falls a whole interval behind, it
+  # resumes from now instead of bursting to catch up (bursts are what trip
+  # GitHub's secondary rate limit).
+  class PageSchedule
+    def initialize(interval)
+      @interval = interval
+      @lock = Mutex.new
+      @next = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def wait_for_slot
+      slot = @lock.synchronize do
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @next = now if @next < now - @interval
+        taken = @next
+        @next += @interval
+        taken
+      end
+      remaining = slot - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      sleep remaining if remaining > 0
+      slot
+    end
+  end
+
+  # Per-page counters shared by that page's senders, printed once a minute.
+  # "overlap" is the share of a poll's ids that were also in the previous
+  # completed poll of the same page: the only cheap signal for whether the
+  # cadence keeps up with the feed (0.7 polls/s gave ~0.05, 1.7 gave 0.43).
+  class PageStats
+    def initialize(page)
+      @page = page
+      @lock = Mutex.new
+      @last_flush = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      @previous_ids = []
+      reset
+    end
+
+    def ok(ids)
+      @lock.synchronize do
+        @polls += 1
+        @events += ids.size
+        unless @previous_ids.empty? || ids.empty?
+          @overlap_sum += (ids & @previous_ids).size.to_f / ids.size
+          @overlap_n += 1
+        end
+        @previous_ids = ids
+      end
+    end
+
+    def failed
+      @lock.synchronize do
+        @polls += 1
+        @failures += 1
+      end
+    end
+
+    def flush_if_due(usable_tokens)
+      line = @lock.synchronize do
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        elapsed = now - @last_flush
+        next nil if elapsed < STATS_EVERY
+
+        overlap = @overlap_n.zero? ? 'n/a' : format('%.2f', @overlap_sum / @overlap_n)
+        text = format('page %d: %.2f polls/s (%d ok, %d failed), %d events, overlap with previous poll %s, usable tokens %d',
+                      @page, @polls / elapsed, @polls - @failures, @failures, @events, overlap, usable_tokens)
+        reset
+        @last_flush = now
+        text
+      end
+      puts line if line
+    end
+
+    private
+
+    def reset
+      @polls = 0
+      @failures = 0
+      @events = 0
+      @overlap_sum = 0.0
+      @overlap_n = 0
+    end
+  end
+
+  class WriterStats
+    def initialize
+      @last_flush = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      reset
+    end
+
+    def record(pages, unique, inserted, already_stored, queue_depth, seconds)
+      @cycles += 1
+      @pages += pages
+      @unique += unique
+      @inserted += inserted
+      @already_stored += already_stored
+      @max_queue = queue_depth if queue_depth > @max_queue
+      @seconds += seconds
+    end
+
+    def flush_if_due
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      elapsed = now - @last_flush
+      return if elapsed < STATS_EVERY
+
+      puts format('writer: %d inserted/min (%d unique fetched from %d pages in %d cycles, %d old events already stored, %.0fms avg write, max queue %d)',
+                  (@inserted * 60 / elapsed).round, @unique, @pages, @cycles, @already_stored,
+                  @cycles.zero? ? 0 : @seconds * 1000 / @cycles, @max_queue)
+      reset
+      @last_flush = now
+    end
+
+    private
+
+    def reset
+      @cycles = 0
+      @pages = 0
+      @unique = 0
+      @inserted = 0
+      @already_stored = 0
+      @max_queue = 0
+      @seconds = 0.0
+    end
   end
 end

--- a/etl/config/initializers/realtime.rb
+++ b/etl/config/initializers/realtime.rb
@@ -163,8 +163,8 @@ class Realtime
     ids = events.map { |e| e['id'].to_i }
     existing = EventLog.where(id: ids).pluck(:id).to_set
     fresh = events.reject { |e| existing.include?(e['id'].to_i) }
-    stored = stored_ids(fresh.select { |e| older_than_window?(e) })
-    fresh = fresh.reject { |e| stored.include?(e['id'].to_i) } unless stored.empty?
+    stored = stored_keys(fresh.select { |e| older_than_window?(e) })
+    fresh = fresh.reject { |e| stored.include?(stored_key(e)) } unless stored.empty?
     fresh.each_slice(WRITE_SLICE) do |es|
       EventLog.insert_all(es.map { |e| { id: e['id'], created_at: Time.now } })
       GithubEvent.insert_all(es)
@@ -178,18 +178,31 @@ class Realtime
     true
   end
 
-  # Ids among `events` that github_events already holds. github_events is
-  # LIST-partitioned by type with a local index on id, so one predicate per
-  # type lets TiDB prune each branch to a single partition; UNION ALL keeps
-  # it to one round trip.
-  def stored_ids(events)
+  # Events among `events` that github_events already holds, as
+  # "id|created_at" keys. The id alone is NOT enough: since 2026-08 the
+  # feed numbers events from a counter that currently sits in the 14.2e9
+  # range and collides with real 2020-11 ids (22% of a 2026-09-01 sample
+  # matched a different, six-year-old event). created_at is part of the
+  # key so a colliding new event is still inserted.
+  #
+  # github_events is LIST-partitioned by type with a local index on id, so
+  # one predicate per type lets TiDB prune each branch to a single
+  # partition; UNION ALL keeps it to one round trip.
+  def stored_keys(events)
     return Set.new if events.empty?
 
     conn = GithubEvent.connection
     sql = events.group_by { |e| e['type'] }.map do |type, es|
-      "SELECT id FROM github_events WHERE type = #{conn.quote(type)} AND id IN (#{es.map { |e| e['id'].to_i }.uniq.join(',')})"
+      "SELECT id, DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%sZ') FROM github_events " \
+        "WHERE type = #{conn.quote(type)} AND id IN (#{es.map { |e| e['id'].to_i }.uniq.join(',')})"
     end.join(' UNION ALL ')
-    conn.select_values(sql).map(&:to_i).to_set
+    conn.select_rows(sql).map { |id, at| "#{id.to_i}|#{at}" }.to_set
+  end
+
+  # The feed's created_at is always "YYYY-MM-DDTHH:MM:SSZ", the same form
+  # stored_keys asks the database for.
+  def stored_key(event)
+    "#{event['id'].to_i}|#{event['created_at']}"
   end
 
   # A dropped connection is the common failure; reconnect and try once more.

--- a/packages/sync-github-data/src/libs/github/octokit.ts
+++ b/packages/sync-github-data/src/libs/github/octokit.ts
@@ -43,6 +43,23 @@ export function getOctokit(token: string | undefined, log: pino.BaseLogger): Oct
 }
 
 export const SYMBOL_TOKEN = Symbol('PERSONAL_TOKEN');
+const SYMBOL_DEAD = Symbol('DEAD_CREDENTIAL');
+
+/**
+ * GitHub refuses a suspended account or a revoked token on every request,
+ * forever, with a 403 that carries no rate-limit headers. The throttling
+ * plugin therefore does not retry it, but nothing removed the worker either:
+ * it stayed in rotation and every time range it drew failed and was logged
+ * as if transient. Measured 2026-09-01: half of this job's tokens were
+ * suspended accounts and it had been drawing them for months.
+ */
+function isDeadCredential(error: any): boolean {
+  const status = Number(error?.status);
+  if (status === 401) {
+    return true;
+  }
+  return status === 403 && /suspended/i.test(String(error?.message ?? ''));
+}
 
 export function eraseToken(value: string | undefined): string {
   return value ? `****${value.substring(value.length - 8)}` : 'anonymous';
@@ -50,18 +67,31 @@ export function eraseToken(value: string | undefined): string {
 
 export class OctokitFactory<T> implements Factory<Octokit> {
   private tokens: Array<string | undefined> = [];
+  private readonly total: number;
+  /** Tokens GitHub has rejected outright; never handed out again. */
+  private readonly dead = new Set<string | undefined>();
 
   constructor(
     tokens: string[],
     readonly logger: pino.Logger
   ) {
     tokens.forEach(token => this.tokens.push(token))
+    this.total = tokens.length;
     this.logger.info('Create workers with %s GitHub tokens.', tokens.length)
   }
 
   async create(): Promise<Octokit> {
     if (this.tokens.length <= 0) {
-      throw new Error('Out of GitHub personal tokens.');
+      if (this.dead.size >= this.total) {
+        this.logger.fatal('All %d GitHub tokens were rejected by GitHub (suspended or revoked); nothing can be synced until they are replaced.', this.total);
+        process.exit(1);
+      }
+      // Every remaining token is bound to a live worker. Throwing here would
+      // make generic-pool dispense again at once and spin on the failure; a
+      // promise that never settles keeps this slot pending instead, which is
+      // exactly the reduced concurrency wanted after losing a credential.
+      this.logger.warn('No spare GitHub token (%d of %d quarantined); continuing with fewer workers.', this.dead.size, this.total);
+      return new Promise<Octokit>(() => {});
     }
 
     // Get access token.
@@ -81,11 +111,39 @@ export class OctokitFactory<T> implements Factory<Octokit> {
       configurable: false
     });
 
+    // Registered after the plugins, so this is the outermost error hook and
+    // sees the error the throttling and retry plugins gave up on.
+    octokit.hook.error('request', (error: any) => {
+      if (isDeadCredential(error) && !this.dead.has(token)) {
+        this.dead.add(token);
+        Object.defineProperty(octokit, SYMBOL_DEAD, {value: true, enumerable: false});
+        log.error('GitHub rejected this credential (%s); quarantining it for the rest of the run, %d of %d tokens left.',
+          error?.message, this.total - this.dead.size, this.total);
+        if (this.dead.size >= this.total) {
+          // Every waiter would otherwise block on a create() that never
+          // settles and the process would sit idle looking healthy. Die
+          // loudly instead so pm2 shows it errored.
+          this.logger.fatal('All %d GitHub tokens were rejected by GitHub (suspended or revoked); nothing can be synced until they are replaced.', this.total);
+          process.exit(1);
+        }
+      }
+      throw error;
+    });
+
     return octokit;
+  }
+
+  /** Called on every borrow (testOnBorrow); a quarantined client is destroyed instead of handed out. */
+  async validate(octokit: Octokit): Promise<boolean> {
+    return !(octokit as any)[SYMBOL_DEAD];
   }
 
   async destroy(octokit: Octokit): Promise<void> {
     const {value} = Object.getOwnPropertyDescriptor(octokit, SYMBOL_TOKEN)!
+    if (this.dead.has(value)) {
+      octokit.log.warn('Dropping quarantined GitHub client; its token will not be reused.');
+      return;
+    }
     this.tokens.push(value);
     octokit.log.info('Release GitHub client.');
   }
@@ -94,7 +152,8 @@ export class OctokitFactory<T> implements Factory<Octokit> {
 export function createOctokitPool<T>(logger: pino.Logger, tokens: string[]): GenericPool<Octokit> {
   return createGenericPool(new OctokitFactory<T>(tokens, logger), {
     min: 0,
-    max: tokens.length
+    max: tokens.length,
+    testOnBorrow: true
   }).on('factoryCreateError', function (err) {
     logger.error('Failed to create worker: ', err)
   }).on('factoryDestroyError', function (err) {


### PR DESCRIPTION
## Why

Capture rate of the live `/events` poller was ~84%: one sequential loop over three pages reached only ~0.67 polls/s/page, while the feed needs ~2 polls/s/page (timed from request send) to be read completely. Separately, half of the `sync-github-data` tokens on api2 were suspended accounts and the job kept drawing them.

## What

**`etl/config/initializers/realtime.rb`** (rewritten)
- Per-page `PageSchedule` hands out send slots 0.5s apart to 4 sender threads per page, so cadence is independent of GitHub latency (page 1 ~0.5s, pages 2–3 ~1.4s).
- Single writer thread: merges queued pages, dedups against `EventLog` and, for events older than 25 min, against `github_events` keyed on **(id, created_at)** per type (`UNION ALL` so TiDB prunes to one partition each).
- `EventLog` retention 5 → 30 min. Round-robin token checkout under a mutex; rejection/exhaustion bookkeeping kept.
- Per-page and writer stats once a minute in the journal (`polls/s`, overlap with previous poll, inserted/min, old events already stored, queue depth).

**`etl/config/initializers/fetch_event.rb`**: `fetch(page)` for a single page; no in-request retry, 5s/15s timeouts (the next slot is the retry).

**`packages/sync-github-data/src/libs/github/octokit.ts`**: quarantine on 401 / 403 "account suspended" via an outermost request error hook + `validate()` with `testOnBorrow`. Out of spare tokens → `create()` returns a never-settling promise (throwing makes generic-pool spin). Last token dead → `process.exit(1)` so pm2 shows it errored. Tested against real 401s: 2 dead + 1 good token → all later calls succeed on the good one; all dead → FATAL, exit 1.

## Measured on data1, 2026-09-01 (5-minute samples before / after)

| | before (2 processes) | after (1 process) |
|---|---|---|
| polls/s page 1 / 2 / 3 | ~0.67 each per process | 2.00 / 1.99 / 2.00 |
| overlap with previous poll | ~0.05 | 0.50–0.61 |
| distinct events inserted / 5 min | 24,176 | 53,732 |
| **true duplicate rows** (same id+type+created_at inserted twice) | **7,096 (29%)** | **0** |
| writer avg write / max queue | – | ~65 ms / 2 pages |

Budget: 3 pages × 2 req/s = 21,600 req/h against 7 tokens × 5,000 = 35,000. **Only one instance may run**; `gh_realtime2` is stopped and disabled on data1 and commented out of `restart_all.sh`.

## Two things found on the way (not fixed here)

1. **Feed event ids now collide with 2020 ids.** Since ~2026-08 the feed numbers events from a counter in the 14.2e9 range; in a 5-minute sample 8,268 of 53,732 fetched ids (15%) already existed in `github_events` as a *different* event from 2020-11 / 2022-01. `id` alone no longer identifies an event anywhere in the table; this PR keys its own check on (id, created_at) so those new events are still inserted.
2. **`rake gh:hourly` is destructive.** It deletes every `github_events` row of the previous hour and re-imports the GH Archive file. GH Archive's hourly files have collapsed (170k events on 2026-08-15 12h → 45k on 08-31 15h → 1.8k on 09-01 19h), so each run replaced ~166k live-captured rows with ~2k. The cron is disabled on data1; the task itself is unchanged in this PR.

## Ops changes on hosts (not in this PR)
- data1: `gh_realtime2` disabled; `gh:hourly` cron commented out with reason; backups under `/home/ubuntu/etl-backup-20260901-*`, `/home/ubuntu/crontab-backup-*`.
- api2: `sync-github-data/.env` reduced from 8 to 4 tokens (4 suspended accounts removed); both pm2 jobs restarted on the patched `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)