### PR TITLE
etl: make the GH Archive hourly import additive instead of delete-and-replace

### DIFF
--- a/etl/lib/importer.rb
+++ b/etl/lib/importer.rb
@@ -171,14 +171,67 @@ class Importer
     end
   end
 
+  # Default is insert_missing: the live poller (Realtime) already holds most
+  # of every hour, and since 2026-09-01 nothing may delete or blindly re-add
+  # what it captured. insert_all / upsert_all remain for loading a range
+  # that is known to be empty.
   def import!
     if ENV['upsert_all']
       upsert_all
     elsif ENV['insert_all']
       insert_all
     else
-      insert_all
+      insert_missing
     end
+  end
+
+  # Ids per lookup query; ~1k keeps each IN list small enough to stay an
+  # index lookup on one partition.
+  LOOKUP_CHUNK = 1000
+  INSERT_SLICE = 10000
+
+  # Insert only the archive events github_events does not already hold, and
+  # say how many it did: that ratio is a direct measurement of the live
+  # poller's capture rate against an independent reader of the same feed.
+  def insert_missing
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    existing = existing_keys(events)
+    missing = events.reject { |e| existing.include?(event_key(e)) }
+    missing.each_slice(INSERT_SLICE) { |es| GithubEvent.insert_all(es) }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+    captured = events.count - missing.count
+    pct = events.count.zero? ? 0.0 : captured * 100.0 / events.count
+    puts format('archive %s: %d events, %d already captured live (%.1f%%), inserted %d in %.1fs',
+                filename, events.count, captured, pct, missing.count, elapsed)
+  end
+
+  # "id|created_at" keys of the given events that github_events already
+  # holds. The id alone is NOT enough: since 2026-08 the /events feed numbers
+  # events from a counter that collides with real 2020 ids, so a matching id
+  # may be a different, six-year-old event. github_events is LIST-partitioned
+  # by type, so one query per type prunes to a single partition.
+  def existing_keys(events)
+    conn = GithubEvent.connection
+    keys = Set.new
+    events.group_by { |e| e['type'] }.each do |type, es|
+      es.map { |e| e['id'].to_i }.uniq.each_slice(LOOKUP_CHUNK) do |ids|
+        sql = "SELECT id, DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%sZ') FROM github_events " \
+              "WHERE type = #{conn.quote(type)} AND id IN (#{ids.join(',')})"
+        conn.select_rows(sql).each { |id, at| keys << "#{id.to_i}|#{at}" }
+      end
+    end
+    keys
+  end
+
+  # Same form existing_keys asks the database for. Archive timestamps are
+  # already "YYYY-MM-DDTHH:MM:SSZ"; the parse guards against a variant.
+  def event_key(event)
+    at = begin
+      Time.iso8601(event['created_at']).utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+    rescue ArgumentError, TypeError
+      event['created_at']
+    end
+    "#{event['id'].to_i}|#{at}"
   end
 
   def upsert_all

--- a/etl/lib/tasks/import.rake
+++ b/etl/lib/tasks/import.rake
@@ -264,13 +264,11 @@ namespace :gh do
 
     filename = "#{date}-#{hour}.json.gz"
     puts "Start import #{date.to_s}-#{hour_str} ..."
-    start_time = "#{date.to_s} #{hour_str}:00:00"
-    end_time   = "#{date.to_s} #{hour_str}:59:59"
-    loop do
-      n = GithubEvent.where(created_at: (start_time..end_time)).limit(10000).delete_all
-      puts "deleted #{n} records"
-      break if n < 10000
-    end
+    # This used to DELETE every github_events row of the hour and re-insert
+    # the archive file, which was right while GH Archive was the complete
+    # record and the live poller a stopgap. By 2026-09-01 the archive file
+    # held ~1.8k events against ~150k captured live, so each run replaced
+    # the hour with 1% of itself. The importer now only adds what is missing.
     importer = Importer.new(filename)
     importer.run!
     puts "Done #{date.to_s}-#{hour_str} ..."
@@ -308,15 +306,7 @@ namespace :gh do
         next if filename == "2020-06-10-12.json.gz"
         puts "Start import gharchive event data from #{from} to #{to} ..."
 
-        hour_str = '%02d' % hour
-        start_time = "#{d.to_s} #{hour_str}:00:00"
-        end_time   = "#{d.to_s} #{hour_str}:59:59"
-        loop do
-          n = GithubEvent.where(created_at: (start_time..end_time)).limit(10000).delete_all
-          puts "deleted #{n} records"
-          break if n < 10000
-        end
-
+        # Additive, like gh:hourly: the importer skips events already stored.
         importer = Importer.new(filename)
         importer.run!
       end


### PR DESCRIPTION
## Why

`rake gh:hourly` (cron `21 * * * *` on data1) **deleted every `github_events` row of the previous hour** and re-inserted the GH Archive file for that hour. That was the right design while GH Archive was the complete record and the live poller a stopgap for the current hour.

GH Archive's hourly files collapsed in late August 2026:

| file | events |
|---|---|
| 2026-08-15-12 | 170,586 |
| 2026-08-31-15 | 44,960 |
| 2026-09-01-19 | 1,838 |

while the live poller captures 100–230k per hour. So every run replaced an hour with ~1% of itself; rows only came back over the following day through the feed's delayed re-serves (hours nuked on 09-01 sat at 12k–40k for hours afterwards).

## What

- **`etl/lib/importer.rb`**: `import!` now defaults to `insert_missing`. It looks up which archive events `github_events` already holds, keyed on **(id, type, created_at)** — since 2026-08 the feed's ids collide with real 2020 ids, so id alone would match a different event — and inserts only the rest (per-type queries so TiDB prunes to one partition, 1,000 ids per query). `insert_all` / `upsert_all` stay available via env for loading a known-empty range.
- **`etl/lib/tasks/import.rake`**: the delete loops are removed from `gh:hourly` and `gh:import`. Re-running any hour is idempotent. (`hourly_old`, which targets `github_events_old`, is untouched.)
- Each run logs `archive <file>: N events, M already captured live (x%), inserted K in Ts` — a free hourly capture-rate probe against an independent reader of the same feed.

## Verified on data1 (2026-09-01)

```
archive 2026-09-01-20.json.gz: 1977 events, 1352 already captured live (68.4%), inserted 625 in 0.7s
```
`github_events` rows for hour 20: 183,741 → 184,366 (+625, nothing removed). Second run of the same hour: inserted 0. The cron is re-enabled with the additive task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)